### PR TITLE
docs(adrs): propose ADR 0008 — yage-manifests GitOps YAML template repo

### DIFF
--- a/docs/architecture/adrs/0008-yage-manifests-gitops-templates.md
+++ b/docs/architecture/adrs/0008-yage-manifests-gitops-templates.md
@@ -1,0 +1,258 @@
+# ADR 0008 — yage-manifests: GitOps YAML Template Repository
+
+**Status:** Proposed
+**Date:** 2026-04-30
+**Owners:** Architect (interface contract, repository structure), Backend (Fetcher implementation, per-package migration)
+
+---
+
+## Context
+
+yage generates all Kubernetes YAML manifests, Helm values, ArgoCD Application resources,
+and CAPI add-on resources as Go string-building code. The current surface is approximately
+3,100 lines spread across six packages:
+
+| Package | Lines | Role |
+|---|---|---|
+| `internal/capi/manifest/` | 1,228 | Workload cluster YAML patching + K3s template generation |
+| `internal/capi/caaph/` | 861 | CAAPH HelmChartProxy YAML + ArgoCD Operator install CR |
+| `internal/capi/wlargocd/` | 409 | Workload ArgoCD Application YAML (one per add-on) |
+| `internal/capi/postsync/` | 223 | ArgoCD PostSync-hook helpers + CSI smoke-test renderers |
+| `internal/capi/cilium/` | 169 | Cilium CNI helper manifests |
+| `internal/capi/helmvalues/` | 251 | Helm values YAML for metrics-server, observability stack |
+| `internal/csi/*/RenderValues()` | ~14 pkgs | Per-driver Helm values YAML |
+
+All of these use `strings.Builder` + `fmt.Fprintf` to assemble YAML inline. This approach
+has several compounding costs:
+
+- YAML output is not reviewable except by reading Go source or running yage.
+- Operators cannot audit or fork the templates without forking the binary.
+- Tests must compare string output against hardcoded literals, which makes template changes
+  expensive and diff-noisy.
+- Adding a new add-on requires modifying and rebuilding yage even when the logic is purely
+  structural YAML.
+- There is no mechanism to pin a manifest version independently of a yage release.
+
+The project owner's architectural direction: move all YAML templating out of Go code into a
+dedicated GitOps repository, following the same pattern established by ADR 0004 for
+OpenTofu modules (`yage-tofu`).
+
+---
+
+## Decision
+
+### 1. `yage-manifests` public repository
+
+A new public GitHub repository `lpasquali/yage-manifests` holds all YAML templates and
+Helm values files. yage contains **no inline YAML assembly**. The repository structure is:
+
+```
+yage-manifests/
+├── cluster/            # CAPI workload cluster manifests per provider
+│   ├── proxmox/
+│   ├── aws/
+│   └── ...
+├── addons/             # Helm values + ArgoCD Application YAMLs per add-on
+│   ├── cilium/
+│   ├── argocd/
+│   ├── metrics-server/
+│   ├── observability/
+│   └── ...
+├── csi/                # Per-driver Helm values (replaces csi.RenderValues)
+│   ├── hcloud/
+│   ├── aws-ebs/
+│   └── ...
+└── postsync/           # ArgoCD PostSync hook manifests
+```
+
+Modules are versioned and tagged independently of yage releases. Operators can audit and
+fork `yage-manifests` without touching the yage binary.
+
+### 2. Templating engine
+
+Template files use Go `text/template` syntax with the extension `.yaml.tmpl`. Rationale:
+yage is a Go binary; `text/template` is stdlib, requires no external process or binary,
+and template rendering is in-process with zero additional dependencies. No Helm,
+no envsubst, no Kustomize — just Go template syntax.
+
+One authoring constraint to note: the CAAPH `HelmChartProxy` resource embeds a
+`valuesTemplate:` block that itself contains `{{ }}` CAAPH-side template expressions.
+When these files move to `yage-manifests`, those inner `{{`/`}}` delimiters must be
+escaped as `{{"{{"}}` / `{{"}}"}}` (or the template must use a custom delimiter pair).
+This is documented in the per-template comment header and is the responsibility of the
+Backend agent during migration.
+
+### 3. Fetch and render mechanism
+
+The `internal/platform/manifests` package introduces a `Fetcher` struct that mirrors the
+pattern established in `internal/platform/opentofux` for the `yage-tofu` checkout. The two
+Fetchers are independent implementations — the manifests Fetcher is a new package, not a
+generic extraction of opentofux. Extracting a shared git-fetch base is deferred until the
+duplication causes pain.
+
+```go
+// internal/platform/manifests/fetcher.go
+type Fetcher struct {
+    RepoURL  string  // https://github.com/lpasquali/yage-manifests
+    Ref      string  // cfg.ManifestsRef (env: YAGE_MANIFESTS_REF, default: latest tag)
+    CacheDir string  // ~/.yage/manifests-cache/
+}
+
+// Render fetches (clone on first use; git fetch + checkout on subsequent runs)
+// the yage-manifests repo at the configured Ref, reads the .yaml.tmpl at
+// templatePath (relative to repo root), executes it with data via text/template,
+// and returns the rendered YAML string.
+func (f *Fetcher) Render(templatePath string, data any) (string, error)
+```
+
+yage replaces each `strings.Builder`-based renderer with a `manifests.Fetcher.Render()`
+call, passing the appropriate `templatePath` and the relevant section of `*config.Config`
+(or a purpose-built data struct) as `data`.
+
+### 4. Patch vs. template distinction
+
+`internal/capi/manifest/patches.go` does **regex-based mutation of externally-supplied
+YAML documents** — the inputs are manifests rendered by `clusterctl generate cluster`,
+not content yage generates from scratch. This is a fundamentally different operation from
+templating, and it stays in Go.
+
+The four patch functions that remain in `internal/capi/manifest/`:
+
+| Function | What it mutates |
+|---|---|
+| `ApplyRoleResourceOverrides` | Sizing fields in `ProxmoxMachineTemplate` blocks |
+| `PatchProxmoxCSITopologyLabels` | CSI topology `node-labels` in `KubeadmConfig` |
+| `PatchKubeadmSkipKubeProxyForCilium` | `skipPhases: - addon/kube-proxy` in `KubeadmControlPlane` |
+| `PatchProxmoxMachineTemplateSpecRevisions` | PMT name revision hashes |
+
+These functions receive clusterctl output and apply structural corrections. They are not
+candidates for `yage-manifests` because their input is dynamic (operator-provided, not
+yage-generated). Future work may introduce a cleaner patch API internally, but that is
+out of scope for this ADR.
+
+`caaph.PatchClusterCAAPHHelmLabels` likewise stays in Go — it mutates a live Cluster
+object in the management cluster via a JSON merge-patch and also updates the on-disk
+manifest in-place. The logic is imperative, not template-shaped.
+
+### 5. `YAGE_MANIFESTS_REF` config field
+
+A new config field `cfg.ManifestsRef string` (env: `YAGE_MANIFESTS_REF`, default: `v0.1.0`
+initially, then tracking the latest stable tag). Analogous to `YAGE_TOFU_REF` from
+ADR 0004.
+
+The Fetcher uses this ref to check out the `yage-manifests` repository. Operators can pin
+to a specific tag for reproducibility. Air-gapped environments must mirror
+`lpasquali/yage-manifests` and set `YAGE_MANIFESTS_REF` to an internally reachable URL.
+
+### 6. `csi.Driver.RenderValues()` migration
+
+The current CSI driver interface declares:
+
+```go
+RenderValues(cfg *config.Config) (string, error)
+```
+
+After migration, this becomes:
+
+```go
+Render(fetcher *manifests.Fetcher, cfg *config.Config) (string, error)
+```
+
+Each driver's implementation becomes a one-line call:
+
+```go
+func (d driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+    return f.Render("csi/"+d.Name()+"/values.yaml.tmpl", cfg)
+}
+```
+
+This is a breaking interface change for all 14 registered driver packages. It is sequenced
+as a single atomic PR that updates `internal/csi/driver.go` and all 14 implementations
+together.
+
+### 7. Migration sequencing
+
+1. **Scaffold** — Create `lpasquali/yage-manifests` with the directory structure above.
+   Populate README stubs per subdirectory; no templates yet.
+2. **Fetcher** — Backend: implement `internal/platform/manifests.Fetcher` (clone/pull
+   logic, `Render` method, cache at `~/.yage/manifests-cache/`, `YAGE_MANIFESTS_REF` config
+   field). Unit-testable with a local file fixture (no network required in CI).
+3. **Per-package migration** (can be parallelised per package):
+   - Port template content from Go string-builder to `.yaml.tmpl` in `yage-manifests`.
+   - Replace the Go renderer with a `Fetcher.Render()` call.
+   - Update tests to use a local file fixture pointing at a `testdata/` copy of the
+     template, so tests do not require network access.
+4. **CSI interface change** — Update `internal/csi/driver.go` interface and all 14 driver
+   packages in one PR. Retire the `RenderValues` name.
+5. **Package retirement** — Once all callers are migrated, retire `internal/capi/helmvalues/`,
+   `internal/capi/wlargocd/`, and `internal/capi/postsync/` as Go packages. Keep
+   `internal/capi/caaph/` for the Kubernetes client logic; only its string-building
+   helpers move out.
+
+---
+
+## Consequences
+
+### Positive
+
+- **YAML is auditable outside the binary.** Operators can read, diff, and fork
+  `yage-manifests` without building or running yage.
+
+- **Manifest version is independently pinnable.** `YAGE_MANIFESTS_REF` decouples
+  template evolution from yage releases, giving operators a stable surface for controlled
+  upgrades.
+
+- **Go packages are smaller and focused.** `helmvalues/`, `wlargocd/`, and `postsync/`
+  become no-op packages on the retirement path; `caaph/` is left with only Kubernetes
+  client logic.
+
+- **New add-ons require no Go change.** A new ArgoCD Application or Helm values block is
+  a PR against `yage-manifests` only, not a yage rebuild.
+
+- **Tests become structural.** Instead of comparing `strings.Builder` output against
+  hardcoded literals, tests validate template rendering against known fixtures and verify
+  that the Fetcher resolves the correct path.
+
+### Negative
+
+- **Network dependency at bootstrap.** yage must clone `yage-manifests` on first use.
+  Mitigated by local cache; subsequent runs only require a `git fetch`. Air-gapped
+  environments must mirror the repository.
+
+- **Additional config surface.** `YAGE_MANIFESTS_REF` is a new env var / flag that
+  operators must understand and optionally pin. Documentation and a sensible default
+  (`v0.1.0`) reduce friction.
+
+- **Migration work across ~15 packages.** All `strings.Builder` renderers must be ported.
+  The migration is mechanical but large. Sequencing per-package migration (step 3) allows
+  incremental merges and keeps PRs reviewable.
+
+- **CSI interface break.** Renaming `RenderValues` to `Render` requires a coordinated
+  change across all 14 driver packages. This is a one-time cost with no ongoing
+  maintenance burden.
+
+### Risks
+
+- **Template drift.** If `yage-manifests` advances independently of yage, a `YAGE_MANIFESTS_REF`
+  bump may introduce templates that reference config fields not yet present in the installed
+  yage binary. Mitigation: templates should only reference fields present in `config.Config`;
+  any new field required by a template must land in yage first. The `yage-manifests`
+  changelog must document required minimum yage versions for each tag.
+
+- **Double-template authoring trap.** CAAPH `HelmChartProxy` resources embed
+  `valuesTemplate:` blocks that contain CAAPH's own `{{ }}` expressions. Template authors
+  must escape these inner delimiters. Failing to do so silently produces broken YAML.
+  A lint step in the `yage-manifests` CI (e.g. `go template validate` or a custom check)
+  should catch unescaped inner delimiters before merge.
+
+---
+
+## References
+
+- ADR 0004 — Universal OpenTofu Identity Bootstrap; establishes the `yage-tofu` / `Fetcher` / pinned-ref pattern this ADR mirrors
+- `lpasquali/yage-manifests` — public repository of YAML templates (target)
+- `internal/capi/manifest/patches.go` — patch functions that stay in Go
+- `internal/capi/caaph/caaph.go` — CAAPH HelmChartProxy + ArgoCD CR renderers (migration target)
+- `internal/capi/wlargocd/render.go` — ArgoCD Application renderers (migration target)
+- `internal/capi/helmvalues/` — Helm values generators (migration target; retirement path)
+- `internal/csi/driver.go` — CSI `Driver` interface (`RenderValues` → `Render`)

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -2,22 +2,39 @@
 
 ## Living Memory
 
-yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is largely complete: phases A, B, C, and E are done; D is substantially complete. Legacy cleanup is in flight per ADR 0002 (no-backward-compatibility policy).
+yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is largely complete: phases A, B, C, and E are done; D is substantially complete. Legacy cleanup is complete per ADR 0002 (no-backward-compatibility policy). ADR 0007 adopted: dashboard is the new default xapiri entry point.
 
 ## Freshness Policy
 
 This file must be updated whenever system state evolves (per CODING_STANDARDS.md "Atomic Persistence"). If information here conflicts with what you observe in the code or git history, trust what you observe now — then update this file to match reality.
 
-Last updated: **2026-04-30** — PRs #72, #73, #74, #75, #76 all merged; issues #66, #70, #69, #67, #82, #83 closed
+Last updated: **2026-04-30** — PO session: ADR 0007 epic (#103, #104, #105) catalogued; agent assignments issued; #68 assigned to lpasquali
 
 ## Version Baseline
 
 | Repo | Branch | Recent PRs | Status |
 |---|---|---|---|
 | yage | `main` | #76 (TUI keymap ADR 0003), #75 (OpenStack), #74 (env aliases), #73 (kindsync cleanup), #72 (vSphere) | Active development |
-| yage-docs | `main` | ADRs 0003–0006 written | Documentation in progress |
+| yage-docs | `main` | ADRs 0001–0007 written; WORKFLOW added | Documentation in progress |
 
 ## Recent Changes
+
+### 2026-04-30 — PO session: ADR 0007 epic opened; agent assignments issued
+
+**New issues opened (ADR 0007 — xapiri dashboard as default entry):**
+- **#104** — epic: ADR 0007 — xapiri dashboard as default entry; deprecate and remove legacy walkthrough
+- **#103** — Phase 1 (Frontend, p1): make dashboard the default entry point; skip pre-dashboard config selection prompt. Key change: `internal/ui/xapiri/xapiri.go:useHuhTUI()` defaults to true when env var unset; `YAGE_XAPIRI_TUI=legacy` opts back for one sprint.
+- **#105** — Phase 2 (Frontend, p3): remove legacy bufio walkthrough entirely. **Blocked**: must not start until one sprint after #103 merges.
+
+**Agent assignments (this session):**
+- **Frontend**: #103 (p1 — start now)
+- **Backend**: #68 (p1 — integrate worktrees A/B/D1/D4), then #71, then #84–#93
+- **Architect**: #81 (p2 — flesh out ADR 0004 OpenTofu Phase G)
+- **Platform Engineer**: no new refinements pending; standby
+
+**GitHub hygiene:** #68 assigned to lpasquali; #103–#105 added to project board.
+
+---
 
 ### 2026-04-30 — PRs #72–#76 merged; issues #66, #67, #69, #70, #82, #83 closed
 
@@ -28,7 +45,7 @@ Last updated: **2026-04-30** — PRs #72, #73, #74, #75, #76 all merged; issues 
 - **#75** — `provider/openstack`: PatchManifest flavor resolution + Inventory via gophercloud; fix flavor env keys. Closes #66.
 - **#73** — `refactor(kindsync)`: remove `SyncProxmoxBootstrapLiteralCredentials` (ADR 0002 item 1). Closes #70 (partial).
 
-**ADRs 0003–0006** written and accepted in `yage-docs`.
+**ADRs 0003–0007** written and accepted in `yage-docs`.
 
 **Issues closed:** #66, #67, #69, #70, #82, #83.
 
@@ -64,19 +81,6 @@ Last updated: **2026-04-30** — PRs #72, #73, #74, #75, #76 all merged; issues 
 - Added: `github.com/gophercloud/gophercloud/v2 v2.12.0` to `go.mod`
 - Added: smoke test `TestTemplateVarsKeysMatchTemplate` guarding the env key correctness
 
-**ADR 0003** written (`yage-docs/docs/architecture/adrs/0003-xapiri-tui-dispatch-keymap.md`):
-- Keymap normalization: remove j/k from 4 dashboard locations + huh picker `WithKeyMap`
-- Promote `inTextField` to method; add `tabCosts+costCredsMode` case
-- `preserveTransientState` helper replaces fragile manual copy in `cfgEntryLoadMsg`
-- Call `detectFork` in `initFromConfig` when InfraProvider empty
-- Inline "location unset" prompt on costs tab when GeoIP off and DataCenterLocation empty
-- **Issue #69** opened for Frontend agent to implement
-
-**Cleanup worktrees** — all three are one commit ahead of `550698e`, need rebase onto `02b1948`:
-- `worktree-agent-a529a47e1fc8d2cf7` (83941d5): ADR 0002 item 1 — remove `SyncProxmoxBootstrapLiteralCredentials` (done); item 7 (`InfraProvider` guard removal) deferred — only TODO comments added, guards still present
-- `worktree-agent-aceeb96a31d0f49b7` (e060830): ADR 0002 items 3+4+5 — remove `OS_*`/`YAGE_CURRENCY` aliases + legacy snapshot JSON
-- `worktree-agent-afd01feec4a66c948` (97b5288): OpenStack #66 — also needs rebase before PR
-
 ---
 
 ### 2026-04-30 — Architect assessment: phase status corrected; ADR 0002 no-compat policy
@@ -86,7 +90,6 @@ Architect audited the codebase and produced §25 addendum to `abstraction-plan.m
 - **Phase status corrected**: CURRENT_STATE previously showed A/B/D/E as "Not started"; ground truth is A/B/E complete, D substantially complete (see Abstraction Plan Status table below).
 - **No-backward-compatibility policy adopted** (ADR 0002): yage has no production users; all legacy fallbacks (dual-read/write migration, env-var aliases, Secret-name fallbacks, JSON-format fallbacks) are dead weight and will be deleted without deprecation cycle.
 - **Three ADR documents written**: §25 addendum to `abstraction-plan.md`; ADR 0001 (CSI driver registry); ADR 0002 (backward compat removal).
-- **Four parallel cleanup agents spawned** to execute ADR 0002 on branches: `refactor/kindsync-cleanup`, `refactor/env-aliases`, `refactor/proxmox-purge-cleanup`, and one additional branch. Status unknown as of this writing — check before starting new work on overlapping files.
 
 ---
 
@@ -96,7 +99,7 @@ Split the previous single "Config" tab in xapiri into two separate tabs:
 - **Config** (tab 1) — profile selection list and new-config name input
 - **Provision** (tab 2) — full interactive edit form for the selected config
 
-Selecting a config from the list automatically switches to the provision tab. All other tabs (3–9) remain gated on `cfgSelected`. Keyboard shortcuts 1–8, ctrl+alt+1–8, and mouse click-to-focus remapped to new indices. Help tab updated. `main` is at `02b1948`; `feat/xapiri-config-provision-split` is 2 commits ahead (b4b09df + 761f900 — proxmox cleanup + vSphere) and awaits merge.
+Selecting a config from the list automatically switches to the provision tab. All other tabs (3–9) remain gated on `cfgSelected`. Keyboard shortcuts 1–8, ctrl+alt+1–8, and mouse click-to-focus remapped to new indices. Help tab updated.
 
 ---
 
@@ -148,16 +151,20 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 | C | Config namespacing (`cfg.Proxmox*` → `cfg.Providers.Proxmox.*`) | **Merged** |
 | A | Inventory behind `Provider.Inventory()` | **Complete** (interface + call sites wired; Proxmox implements; cleanup in progress) |
 | B | Plan body delegation per provider | **Complete** (DescribeIdentity/DescribeWorkload/DescribePivot wired; Proxmox implements) |
-| D | Generic kindsync + Purge | **Substantially complete** (KindSyncFields + WriteBootstrapConfigSecret in use; legacy wrappers being removed — see ADR 0002) |
+| D | Generic kindsync + Purge | **Substantially complete** (KindSyncFields + WriteBootstrapConfigSecret in use; legacy wrappers removed per ADR 0002) |
 | E | Pivot generalization (kind → any-cloud mgmt) | **Complete** (PivotTarget called via interface in pivot.go) |
 
 ---
 
 ## Active Work
 
-| Branch | Owner | Description | Status |
-|---|---|---|---|
-| *(none — all recent branches merged)* | — | — | — |
+| Issue | Branch | Agent | Description | Status |
+|---|---|---|---|---|
+| #103 | feat/xapiri-dashboard-default | Frontend | ADR 0007 Phase 1: dashboard as default entry point | **Assigned** |
+| #68 | TBD | Backend | Integrate worktrees A/B/D1/D4 into main | **Assigned** |
+| #81 | TBD | Architect | Flesh out ADR 0004: OpenTofu Phase G universal identity | **Assigned** |
+| #104 | — | — | Epic: ADR 0007 (parent of #103, #105) | Open |
+| #105 | — | Frontend | ADR 0007 Phase 2: remove legacy walkthrough | **Blocked** on #103 + 1 sprint |
 
 ---
 
@@ -165,17 +172,27 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 - xapiri is still a work-in-progress TUI; not all provider paths are fully wired.
 - Cost estimation requires live Proxmox API; returns `ErrUnavailable` when unreachable.
-- xapiri TUI: `feat/xapiri-tui-dispatch-fixes` fixes j/k, inTextField guard, detectFork, and costs tab prompt (ADR 0003 / issue #69) — pending merge.
 - vSphere `Inventory()`: `Cores=0` — CPU expressed in MHz only (cannot derive cores from ResourcePool quota alone without host-speed query).
+- #68 worktrees (A/B/D1/D4): status unknown — Backend must locate branches before implementing; may need fresh implementation if worktrees are gone.
 
 ## Next Steps
 
-1. **Issue #68** (p1) — integrate background A/B/D1/D4 worktrees (Backend); ordering constraint: D1 after B; delete `internal/capi/csi/` post-D1 per ADR 0001.
-2. **Issue #71** (p2) — ADR 0002 item 7: remove redundant `cfg.InfraProvider == "proxmox"` guards (Backend).
-3. **Issue #81** (p2) — flesh out ADR 0004: OpenTofu Phase G universal identity bootstrap (Architect).
-4. **Issues #84–#93** (p2) — 10 CSI driver implementations per ADR 0001 (Backend, epic #77).
-5. **Issues #94–#101** (p2) — 8 PlanDescriber provider implementations (Backend, epic #78).
-6. **Issues #79, #80** (p3) — vSphere PatchManifest sizing + OpenStack EnsureIdentity clouds.yaml (Backend).
+### Immediate (current sprint)
+
+1. **Issue #103** (p1, Frontend) — ADR 0007 Phase 1: make dashboard the default xapiri entry point. Key file: `internal/ui/xapiri/xapiri.go:useHuhTUI()`. Branch: `feat/xapiri-dashboard-default`.
+2. **Issue #68** (p1, Backend) — Locate and integrate worktrees A/B/D1/D4. Ordering: D1 after B. Delete `internal/capi/csi/` post-D1 per ADR 0001.
+
+### Planned (next sprint)
+
+3. **Issue #81** (p2, Architect) — Flesh out ADR 0004: OpenTofu Phase G universal identity bootstrap (Phase G).
+4. **Issue #71** (p2, Backend) — ADR 0002 item 7: remove redundant `cfg.InfraProvider == "proxmox"` guards.
+5. **Issues #84–#93** (p2, Backend) — 10 CSI driver implementations per ADR 0001 (epic #77). Note: may be partially done if worktree B in #68 is recoverable.
+6. **Issues #79, #80** (p3, Backend) — vSphere PatchManifest sizing + OpenStack EnsureIdentity clouds.yaml.
+
+### Backlog
+
+7. **Issue #105** (p3, Frontend) — ADR 0007 Phase 2: remove legacy bufio walkthrough. **Blocked**: one sprint after #103 merges.
+8. **Issues #94–#101** (p3, Backend) — 8 PlanDescriber provider implementations (epic #78).
 
 ---
 
@@ -187,4 +204,4 @@ Three open issues refined with K8s/infra-level implementation specs:
 - **#67** (vSphere Inventory + EnsureScope): govmomi not yet in go.mod — must be added. ResourcePool property query path specified. Unlimited pool (`-1`) edge case: return `ErrNotApplicable`. TLS thumbprint field check required.
 - **#68** (Background agent integration): D1 depends on B. Ordering constraint: proxmox-csi `EnsureSecret` must run before HelmChartProxy fires. Post-D1: delete `internal/capi/csi/` per ADR 0001.
 
-**Handoff to Backend:** #66 and #67 are ready for implementation. #68 is integration ops — check worktree/branch status of A/B/D1/D4 before starting.
+**Handoff to Backend:** #66 and #67 are resolved (merged in #75, #72). #68 is integration ops — check worktree/branch status of A/B/D1/D4 before starting.


### PR DESCRIPTION
## Summary

- Proposes ADR 0008: move all YAML/Helm-values generation out of Go `strings.Builder` code into a new public `lpasquali/yage-manifests` repository, following the same pattern as `yage-tofu` (ADR 0004).
- Documents the `internal/platform/manifests.Fetcher` contract, `YAGE_MANIFESTS_REF` config field, and the `csi.Driver.Render` interface change.
- Explicitly distinguishes templates (move to yage-manifests) from patches (stay in Go), naming the four `manifest/patches.go` functions that remain.

## Test plan

- [x] `mkdocs build --strict` passes
- [x] No broken internal links (ADR references existing files by path)
- [x] No Go code changed

## Definition of Done

- [x] **Level 3 — Documentation Only**: `mkdocs build --strict` passes; no broken internal links.

## Acceptance Criteria Evidence

```
INFO    -  Documentation built in 1.18 seconds
```

`mkdocs build --strict` exits 0. ADR 0008 file is not in the nav (consistent with all other ADRs in the repo).

## Audit Checks

No triggers fired. Documentation-only change; no Go code, no `go.mod`, no secrets, no CI workflow changes.

## Breaking Changes

None to docs. The ADR itself proposes future breaking changes to Go code (CSI `RenderValues` → `Render`, retirement of `helmvalues/`/`wlargocd/`/`postsync/`); those are sequenced as separate backend PRs after this ADR is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)