### PR TITLE
docs(adr-0009): accept Phase H — on-prem platform services via OpenTofu

### DIFF
--- a/docs/architecture/adrs/0009-on-prem-platform-services.md
+++ b/docs/architecture/adrs/0009-on-prem-platform-services.md
@@ -1,0 +1,307 @@
+# ADR 0009 — On-Prem Platform Services: Bootstrap Registry and Online Issuing CA (Phase H)
+
+**Status:** Accepted
+**Date:** 2026-04-30
+**Owners:** Backend (EnsureRegistry, EnsureIssuingCA wiring), Architect (interface contract)
+
+---
+
+## Context
+
+yage targets on-premises Proxmox deployments that are often deployed in air-gapped or
+partially-gapped environments. The existing airgap surface in the codebase already covers
+several operator-supplied knobs:
+
+| Config field | Env var | What it does |
+|---|---|---|
+| `Airgapped bool` | `YAGE_AIRGAPPED` | Disables every outbound internet call |
+| `ImageRegistryMirror string` | `YAGE_IMAGE_REGISTRY_MIRROR` | Prefixes all CAPI/CNI container image pulls with an internal registry URL |
+| `HelmRepoMirror string` | `YAGE_HELM_REPO_MIRROR` | Rewrites Helm chart repo URLs to an internal mirror |
+| `InternalCABundle string` | `YAGE_INTERNAL_CA_BUNDLE` | Path to a PEM bundle; applied to `http.DefaultTransport` and `SSL_CERT_FILE` for child processes |
+
+These fields are consumed by `internal/platform/airgap/` (`Apply`, `helmrepo.Rewrite`,
+`HTTPClient`). cert-manager is already integrated as a platform add-on and is installed on
+every workload cluster.
+
+Two gaps remain that block a fully-automated air-gapped on-premises bootstrap:
+
+**Gap 1 — No registry VM.** Before the workload cluster can be brought up, a container
+registry must exist to serve CAPI provider images, CNI images, and Helm chart tarballs.
+Today this registry must be pre-staged by the operator out-of-band. There is no yage phase
+that provisions or seeds the registry. Operators must manually:
+
+1. Provision a VM (or bare-metal host) running a container registry.
+2. Push all required images into it.
+3. Set `YAGE_IMAGE_REGISTRY_MIRROR` to the registry's URL.
+4. Then run yage.
+
+This creates a chicken-and-egg problem: yage can orchestrate infrastructure, but the
+infrastructure registry it depends on is outside yage's lifecycle.
+
+**Gap 2 — No issuing CA.** cert-manager's `ClusterIssuer` on the workload cluster has no
+signing material until the operator manually creates the issuer Secret containing an
+intermediate CA key and certificate. Today yage does not provision or wire this material;
+operators must create the Secret before ArgoCD syncs the cert-manager configuration. For
+on-prem deployments that own a private PKI, this requires coordinating cert-manager
+installation timing with offline CA operations.
+
+**Offline root CA:** The root CA is cold, operator-managed, and single-region. yage must not
+automate the root CA lifecycle. The offline root CA is out of scope for automation now and
+permanently. yage's existing `--internal-ca-bundle` consumption boundary is correct and does
+not change. Phase H only introduces the intermediate/issuing CA layer, which is signed by
+the offline root out-of-band by the operator before yage runs.
+
+---
+
+## Decision
+
+### 1. Bootstrap registry — OpenTofu-provisioned Proxmox VM
+
+The registry is provisioned by OpenTofu before the kind cluster phase using a new module
+`yage-tofu/registry/` in the `lpasquali/yage-tofu` repository. This follows the same
+Fetcher + Runner pattern established by ADR 0004 (Phase G):
+
+- The `Fetcher` component in `internal/platform/opentofux` clones/updates `yage-tofu` at
+  `YAGE_TOFU_REF` into `~/.yage/tofu-cache/` (same checkout used by Phase G providers).
+- A `Runner` is constructed with `ModuleDir` pointing at `<tofu-cache>/registry/`.
+- `tofu apply` provisions a Harbor VM on Proxmox using operator-supplied variables:
+  `YAGE_REGISTRY_NODE` (Proxmox node), `YAGE_REGISTRY_VM_FLAVOR` (CPU/RAM template),
+  `YAGE_REGISTRY_NETWORK` (bridge name), `YAGE_REGISTRY_STORAGE` (storage pool).
+- `tofu output` reads the provisioned VM's IP address.
+- yage automatically sets `cfg.ImageRegistryMirror` to `https://<registry-ip>` before
+  the kind cluster phase begins. The operator does not need to set `YAGE_IMAGE_REGISTRY_MIRROR`
+  manually when `YAGE_REGISTRY_NODE` is configured.
+
+The registry VM runs [Harbor](https://goharbor.io/) (the default) or
+[Zot](https://zotregistry.dev/) (opt-in via `YAGE_REGISTRY_FLAVOR=zot`). Harbor is the
+default because it supports native multi-region replication (see §5 below). Zot is available
+for operators who prefer a lighter footprint and do not need replication.
+
+OpenTofu state for the registry lives at `~/.yage/tofu/registry/terraform.tfstate`. On
+`--purge`, yage runs `tofu destroy` before removing the state directory, following the
+same ordering constraint as all Phase G providers (destroy before `os.RemoveAll`).
+
+Image seeding (pushing CAPI provider images, CNI images, and Helm chart tarballs into the
+registry) is an **operator step** for Phase H. A `--seed-registry` automation flag that
+calls `crane copy` or equivalent for each required image is deferred to a follow-up issue.
+The registry module outputs the push URL and credentials; the operator uses these to seed.
+
+### 2. Bootstrap sequence
+
+The full on-prem air-gapped bootstrap sequence for Phase H is:
+
+```mermaid
+sequenceDiagram
+    participant Op as Operator
+    participant yage
+    participant Tofu as OpenTofu (yage-tofu)
+    participant Reg as Registry VM (Proxmox)
+    participant Kind as kind cluster
+    participant WL as Workload cluster
+    participant CM as cert-manager
+
+    Op->>yage: yage bootstrap --airgapped
+    yage->>Tofu: tofu apply yage-tofu/registry/ (YAGE_REGISTRY_NODE, …)
+    Tofu->>Reg: Provision Harbor VM on Proxmox
+    Reg-->>Tofu: VM IP
+    Tofu-->>yage: registry_ip output
+    yage->>yage: Set ImageRegistryMirror = https://<registry-ip>
+    Op->>Reg: Seed CAPI/CNI/Helm images (manual, Phase H)
+    yage->>Kind: kind create cluster (images from registry mirror)
+    yage->>Tofu: tofu apply yage-tofu/issuing-ca/ (intermediate CA vars)
+    Tofu-->>yage: ca.crt, tls.key (intermediate CA material)
+    yage->>Kind: Create cert-manager issuer Secret in yage-system ns
+    yage->>WL: clusterctl generate + apply workload manifests
+    yage->>WL: Install cert-manager; apply ClusterIssuer backed by issuer Secret
+    WL-->>CM: ClusterIssuer ready (signs workload TLS certs)
+    yage->>WL: Optional: clusterctl pivot kind → permanent mgmt cluster
+    yage->>WL: Install ArgoCD on workload cluster
+```
+
+Steps in order:
+
+1. **kind cluster up** (existing phase — unchanged)
+2. **OpenTofu**: `yage-tofu/registry/` provisions the Harbor registry VM on Proxmox;
+   yage reads the VM IP and wires `ImageRegistryMirror` automatically.
+3. **Seed registry**: operator pushes CAPI/CNI/Helm images into the registry
+   (manual step for Phase H; `--seed-registry` is a follow-up).
+4. **Bootstrap workload cluster** with `YAGE_IMAGE_REGISTRY_MIRROR` → registry VM IP;
+   all image pulls route through the local registry.
+5. **Optional pivot**: CAPI management plane moves from kind to a permanent management
+   cluster if configured.
+6. **cert-manager `ClusterIssuer`** wired to intermediate CA material on the workload
+   cluster; signing of workload TLS certs is fully automated from this point.
+
+### 3. Online issuing CA
+
+The intermediate CA is provisioned by a second OpenTofu module `yage-tofu/issuing-ca/`,
+also fetched via the same `YAGE_TOFU_REF` checkout. The module takes the offline root CA
+material as input variables (`YAGE_ISSUING_CA_ROOT_CERT`, `YAGE_ISSUING_CA_ROOT_KEY`) and
+generates an intermediate key pair signed by the root. Outputs are the intermediate CA
+certificate (`ca.crt`) and private key (`tls.key`).
+
+yage reads these outputs and creates a Kubernetes `Secret` of type `kubernetes.io/tls` in
+the `cert-manager` namespace on the workload cluster before cert-manager is installed:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: yage-issuing-ca
+  namespace: cert-manager
+type: kubernetes.io/tls
+data:
+  tls.crt: <base64(intermediate-cert + root-cert chain)>
+  tls.key: <base64(intermediate-key)>
+```
+
+cert-manager's `ClusterIssuer` manifest (applied by the add-on phase) references this
+Secret:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: yage-internal-issuer
+spec:
+  ca:
+    secretName: yage-issuing-ca
+```
+
+No Vault, no step-ca, no ACME for Phase H. The intermediate CA approach gives operators
+full PKI control (they own the root CA) while automating the issuing CA lifecycle end-to-end
+within yage's bootstrap run.
+
+The `yage-tofu/issuing-ca/` module uses the [TLS Terraform provider](https://registry.terraform.io/providers/hashicorp/tls/latest)
+to generate the intermediate key pair deterministically. The OpenTofu state for the issuing
+CA lives at `~/.yage/tofu/issuing-ca/terraform.tfstate`. On `--purge`, `tofu destroy` is
+called before state directory removal — this invalidates the intermediate key, which is the
+correct behavior.
+
+### 4. Offline root CA boundary
+
+**Explicit non-goal**: yage never automates the offline root CA. The offline root is cold,
+operator-managed, and single-region. This boundary does not change with Phase H.
+
+The operator's workflow with the offline root CA:
+
+1. Generate the root CA key and self-signed certificate offline (air-gapped workstation or
+   HSM) using any toolchain (cfssl, openssl, step-ca, EJBCA).
+2. Supply the root cert as the `--internal-ca-bundle` PEM path (`YAGE_INTERNAL_CA_BUNDLE`).
+   This is already implemented and consumed by `internal/platform/airgap/Apply`.
+3. Supply the root cert + key as `YAGE_ISSUING_CA_ROOT_CERT` and `YAGE_ISSUING_CA_ROOT_KEY`
+   for the `yage-tofu/issuing-ca/` module. These are passed as `-var` flags to `tofu apply`
+   and are never persisted to disk by yage (they exist only as process env for the duration
+   of the apply invocation).
+
+The root CA material must never appear in yage's kind Secrets, CURRENT_STATE, or any
+persistent store managed by yage. This is enforced by convention and code review.
+
+### 5. Registry HA topology
+
+**Single-region HA**: one registry VM on Proxmox with an active/passive PVC provided by
+Proxmox CSI (default storage class). Harbor uses this PVC for its registry storage layer.
+No second replica is required for single-region HA because Harbor's registry data is on
+a replicated PVC (Longhorn or rook-ceph as opt-in storage backend) that survives VM restart.
+The `yage-tofu/registry/` module provisions one VM; HA at the storage layer is handled by
+the underlying Proxmox CSI driver.
+
+**Multi-region stretched cluster**: Harbor native replication between two registry VMs, one
+per region. yage provisions the primary registry (first region) via `yage-tofu/registry/`.
+Operators configure replication targets via a future config field
+`YAGE_REGISTRY_REPLICATION_TARGETS` (comma-separated list of secondary registry URLs). This
+field is out of scope for Phase H and will be tracked in a follow-up issue. The primary
+registry VM is fully functional as a standalone registry without replication configuration.
+
+### 6. KubeVirt — explicit rejection
+
+KubeVirt was evaluated as an alternative host for the bootstrap registry (running the
+registry as a `VirtualMachineInstance` Pod on the kind management cluster instead of a
+dedicated Proxmox VM). It was rejected for bootstrap use for the following reasons:
+
+- `/dev/kvm` is not available inside Docker Desktop on macOS or Windows, which are the
+  primary development environments for yage operators. KubeVirt without KVM falls back to
+  QEMU software emulation, which is unacceptably slow for a registry workload.
+- KubeVirt adds a nested-virtualization platform requirement that yage does not currently
+  detect or enforce at preflight. Silently running in emulation mode would not surface the
+  performance degradation clearly to the operator.
+- A Proxmox VM provisioned via `yage-tofu/registry/` (the chosen approach) achieves the
+  same registry-handoff semantics without KVM. It uses the same OpenTofu lifecycle that
+  already exists for identity bootstrap (ADR 0004), and the VM runs at native hypervisor
+  speed on the Proxmox host.
+
+KubeVirt remains a valid Day-2 placement option for running workloads on an established
+Proxmox cluster. It is not in scope for yage's bootstrap orchestration.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Air-gapped on-premises deployments work end-to-end without manual pre-staging.** yage
+  provisions the registry VM, wires the mirror URL, and configures the issuing CA in a
+  single bootstrap run. The operator provides the offline root CA material; everything else
+  is automated.
+
+- **Operator mental model is consistent with Phase G.** The same pattern — one external
+  repo (`yage-tofu`), one Fetcher+Runner lifecycle, one `YAGE_TOFU_REF` pin — covers
+  identity bootstrap, registry provisioning, and CA material generation. Operators do not
+  learn a new tool or lifecycle.
+
+- **cert-manager `ClusterIssuer` is fully automated.** The issuing CA material is generated,
+  applied as a Kubernetes Secret, and wired into cert-manager without any operator
+  intervention after the root CA inputs are provided.
+
+- **Offline root CA boundary is unchanged.** Operators retain full control of the root CA.
+  The automation boundary is strictly the intermediate CA and below.
+
+- **Registry HA at the storage layer.** Single-region HA is handled by Proxmox CSI
+  (Longhorn/rook-ceph), not by running multiple registry replicas. This simplifies the
+  `yage-tofu/registry/` module while still providing the durability operators need.
+
+### Negative / mitigations
+
+- **New config surface**: `YAGE_REGISTRY_NODE`, `YAGE_REGISTRY_VM_FLAVOR`,
+  `YAGE_REGISTRY_NETWORK`, `YAGE_REGISTRY_STORAGE`, `YAGE_REGISTRY_FLAVOR`,
+  `YAGE_ISSUING_CA_ROOT_CERT`, `YAGE_ISSUING_CA_ROOT_KEY` — seven new env vars. Mitigated
+  by sensible defaults where possible (`YAGE_REGISTRY_FLAVOR=harbor`) and by the xapiri
+  TUI surfacing them as a guided configuration flow.
+
+- **Registry VM provisioning adds ~2–3 minutes to bootstrap time.** The `yage-tofu/registry/`
+  apply step provisions a new VM on Proxmox before kind startup. This is a fixed cost on
+  first bootstrap; subsequent runs that detect an existing registry (output already in
+  OpenTofu state) skip re-provisioning.
+
+- **Image seeding is an operator step for Phase H.** Pushing CAPI/CNI/Helm images into the
+  registry is not automated in Phase H. A `--seed-registry` flag that drives `crane copy`
+  (or equivalent) for the required image set is a planned follow-up and will be tracked in
+  a child issue.
+
+- **Multi-region replication config is deferred.** `YAGE_REGISTRY_REPLICATION_TARGETS` is
+  out of scope for Phase H. Single-region deployments are unaffected; multi-region operators
+  must configure Harbor native replication manually until the follow-up issue is resolved.
+
+- **Root CA inputs must be supplied as env vars.** `YAGE_ISSUING_CA_ROOT_CERT` and
+  `YAGE_ISSUING_CA_ROOT_KEY` hold sensitive key material. Operators running yage in CI must
+  use a secrets manager or vault to inject these. This is the standard requirement for any
+  credential input to yage's bootstrap phase and is not a new class of risk.
+
+---
+
+## References
+
+- ADR 0004 (Phase G) — Universal OpenTofu identity bootstrap; Fetcher+Runner pattern that
+  Phase H extends
+- [abstraction-plan.md](abstraction-plan.md) — §21.2 and §21.4 context for the air-gapped
+  topology design
+- `internal/platform/airgap/` — existing airgap consumption layer
+  (`Apply`, `helmrepo.Rewrite`, `HTTPClient`)
+- `internal/platform/opentofux/` — Runner/Fetcher reference implementation
+- `internal/config/config.go` — `Airgapped`, `ImageRegistryMirror`, `HelmRepoMirror`,
+  `InternalCABundle` fields (already implemented)
+- `lpasquali/yage-tofu` — OpenTofu module repository; Phase H adds `registry/` and
+  `issuing-ca/` modules
+- Epic #120 — on-prem platform services
+- Issue #121 — this ADR
+- Issue #118 — D1: orchestrator CSI wiring (same sprint; independent)

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -8,7 +8,7 @@ yage is in active development. The core bootstrap pipeline is functional for Pro
 
 This file must be updated whenever system state evolves (per CODING_STANDARDS.md "Atomic Persistence"). If information here conflicts with what you observe in the code or git history, trust what you observe now — then update this file to match reality.
 
-Last updated: **2026-04-30** — PO audit: PRs #117 + #116 merged (xapiri dashboard-only + vsphere-csi); CSI wave: 5 of 10 drivers merged (#107 hcloud, #108 openebs, #109 rook-ceph, #116 vsphere + earlier #88); 6 CSI PRs still in-flight (#110–#115); new issues #118–#121; yage-docs PR #5 open
+Last updated: **2026-04-30** — PO audit (session 2): PR #122 new (E2BIG fix, MERGEABLE); CSI status: #111 MERGEABLE, #112/#113/#114/#115 CONFLICTING (need rebase), #110 OCI anomaly (issue #86 closed, PR still open — verify); yage-docs PRs #5 and #6 both MERGEABLE; p3 backlog issues #71, #78–#80, #94–#101 fully enumerated in Active Work
 
 ## Version Baseline
 
@@ -18,6 +18,27 @@ Last updated: **2026-04-30** — PO audit: PRs #117 + #116 merged (xapiri dashbo
 | yage-docs | `main` | ADRs 0001–0007 written; WORKFLOW added | Documentation in progress |
 
 ## Recent Changes
+
+### 2026-04-30 — PO audit (session 2): PR #122 new; CSI conflict triage; yage-docs PRs #5 and #6 both ready
+
+**New PR #122 — not previously tracked:**
+- `fix(manifest): avoid E2BIG when clusterctl env inherits large parent vars` on `fix/clusterctl-env-arg-max`
+- Status: MERGEABLE, all checks green. Ready for Programmer to merge immediately.
+- Fix: `BuildEnv()` in `internal/capi/manifest` deduplicates `os.Environ()` before appending overrides; eliminates `E2BIG` on large `~/.ssh/authorized_keys` or other large inherited vars.
+
+**CSI wave status update (as of this audit):**
+- #111 (do-block-storage): MERGEABLE — ready for Programmer.
+- #112 (longhorn): CONFLICTING — needs Backend rebase onto current main, then Programmer merge. Closes #89.
+- #113 (linode-block-storage): CONFLICTING — needs Backend rebase onto current main, then Programmer merge. Closes #87.
+- #114 (ibm-vpc-block): CONFLICTING — needs Backend rebase onto current main, then Programmer merge. Closes #90.
+- #115 (openstack-cinder): CONFLICTING — needs Backend rebase onto current main, then Programmer merge. Closes #88.
+- #110 (oci-block-storage): ANOMALY — issue #86 is already CLOSED (likely auto-closed by an earlier merge); PR #110 still open on `worktree-agent-a015af3c2c642e63e`. Programmer should verify whether work is already in main and close #110 if duplicate; otherwise Backend should rebase and Programmer should merge.
+
+**yage-docs PRs:**
+- PR #5 (`docs/81-adr-0004-phase-g`): MERGEABLE — Programmer to merge; closes #81.
+- PR #6 (`docs/121-adr-0009-platform-services`): MERGEABLE — Programmer to merge; closes #121.
+
+---
 
 ### 2026-04-30 — PO audit: xapiri #117 + vsphere-csi #116 merged; CSI wave ongoing; new issues #118–#121
 
@@ -182,15 +203,35 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 ## Active Work
 
-| Issue | Branch | Agent | Description | Status |
+| Issue / PR | Branch | Agent | Description | Status |
 |---|---|---|---|---|
-| #84–#93 | Various worktree-agent-* | Backend | 10 CSI driver PRs (ADR 0001 epic #77) | Merging (#107–#116); 5 merged, 6 in-flight |
-| #81 | docs/81-adr-0004-phase-g (yage-docs) | Architect | ADR 0004: Phase G universal OpenTofu identity | **PR #5 open** — https://github.com/lpasquali/yage-docs/pull/5 |
-| #118 | TBD | Backend | D1: wire csi.Selector into orchestrator; delete internal/capi/csi/ | **Assigned** — unblocked |
-| #121 | TBD | Architect | ADR 0009: Phase H on-prem platform services (registry + issuing CA) | **Assigned** |
-| #120 | — | — | Epic: on-prem platform services via OpenTofu (airgap path) | Open |
-| #104 | — | — | Epic: ADR 0007 (parent of #103, #105 — both now closed) | Open |
-| #119 | — | Frontend | D4: CAPD smoke E2E test for bootstrap pipeline | Backlog |
+| PR #122 | fix/clusterctl-env-arg-max | **Programmer** | Merge fix: E2BIG clusterctl env dedup — all checks green, MERGEABLE | **Ready to merge** |
+| PR #111 (#85) | worktree-agent-aa17db78e36720843 | **Programmer** | Merge CSI: do-block-storage — MERGEABLE, checks green | **Ready to merge** |
+| PR #112 (#89) | worktree-agent-a4a291be8efba0087 | **Backend** → Programmer | Rebase longhorn CSI onto main (CONFLICTING), then merge | **Needs rebase** |
+| PR #113 (#87) | worktree-agent-a785ce9b3ce84e29d | **Backend** → Programmer | Rebase linode-block-storage CSI onto main (CONFLICTING), then merge | **Needs rebase** |
+| PR #114 (#90) | worktree-agent-acd5c30ba3b59776b | **Backend** → Programmer | Rebase ibm-vpc-block CSI onto main (CONFLICTING), then merge | **Needs rebase** |
+| PR #115 (#88) | feat/csi-openstack-cinder | **Backend** → Programmer | Rebase openstack-cinder CSI onto main (CONFLICTING), then merge | **Needs rebase** |
+| PR #110 | worktree-agent-a015af3c2c642e63e | **Programmer** | Verify OCI anomaly: issue #86 already closed; check if oci-block-storage already in main; close PR if duplicate, else rebase | **Verify/close** |
+| PR #5 (yage-docs) | docs/81-adr-0004-phase-g | **Programmer** | Merge ADR 0004 (Phase G OpenTofu identity) — MERGEABLE | **Ready to merge** — closes #81 |
+| PR #6 (yage-docs) | docs/121-adr-0009-platform-services | **Programmer** | Merge ADR 0009 (Phase H on-prem platform services) — MERGEABLE | **Ready to merge** — closes #121 |
+| #118 | TBD | **Backend** | D1: wire csi.Selector into orchestrator; delete internal/capi/csi/ | **Assigned** — p1, start after CSI PRs land |
+| #71 | TBD | **Backend** | ADR 0002 item 7: remove redundant `cfg.InfraProvider == "proxmox"` guards | **Planned** — p2 next sprint |
+| #79 | TBD | **Backend** | vSphere PatchManifest: honor VSphereMachineTemplate sizing fields | **Planned** — p3 |
+| #80 | TBD | **Backend** | OpenStack EnsureIdentity: template clouds.yaml from config fields | **Blocked** on PR #5 merge — p3 |
+| #94 | TBD | **Backend** | PlanDescriber (DescribeIdentity/Workload/Pivot) for Linode | **Backlog** — p3 (epic #78) |
+| #95 | TBD | **Backend** | PlanDescriber for CAPD (docker) | **Backlog** — p3 (epic #78) |
+| #96 | TBD | **Backend** | PlanDescriber for OpenStack | **Backlog** — p3 (epic #78) |
+| #97 | TBD | **Backend** | PlanDescriber for vSphere | **Backlog** — p3 (epic #78) |
+| #98 | TBD | **Backend** | PlanDescriber for Azure | **Backlog** — p3 (epic #78) |
+| #99 | TBD | **Backend** | PlanDescriber for IBM Cloud | **Backlog** — p3 (epic #78) |
+| #100 | TBD | **Backend** | PlanDescriber for GCP | **Backlog** — p3 (epic #78) |
+| #101 | TBD | **Backend** | PlanDescriber for DigitalOcean | **Backlog** — p3 (epic #78) |
+| #81 | docs/81-adr-0004-phase-g (yage-docs) | Architect | ADR 0004: Phase G universal OpenTofu identity — **DONE, PR #5 ready** | Waiting on Programmer |
+| #121 | docs/121-adr-0009-platform-services (yage-docs) | Architect | ADR 0009: Phase H on-prem platform services — **DONE, PR #6 ready** | Waiting on Programmer |
+| #120 | — | — | Epic: on-prem platform services via OpenTofu (airgap path) | Open — parent of #121 |
+| #104 | — | — | Epic: ADR 0007 (parent of #103, #105 — both now closed) | Open — parent epic |
+| #119 | — | **Backend** | D4: CAPD smoke E2E test for bootstrap pipeline | **Backlog** — p3 |
+| #78 | — | — | Epic: PlanDescriber missing for 8 providers (children: #94–#101) | Open — parent epic |
 
 ---
 
@@ -205,21 +246,24 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 ### Immediate (current sprint)
 
-1. **Let programmer merge remaining CSI PRs #110/#111/#112/#113/#114/#115** (Backend) — each is one clean commit; rebase #110 (oci, has conflicts) first.
-2. **Merge yage-docs PR #5** (Architect) — ADR 0004 + CURRENT_STATE on `docs/81-adr-0004-phase-g`.
-3. **Start #118** (p1, Backend) — D1: wire `csi.Selector` into orchestrator; delete `internal/capi/csi/`. Already unblocked (openstack-cinder in main via #88).
-4. **Start #121** (p2, Architect) — ADR 0009 Phase H: on-prem platform services spec.
+1. **Programmer: merge PR #122** — E2BIG clusterctl fix, MERGEABLE, all checks green.
+2. **Programmer: merge PR #111** — do-block-storage CSI, MERGEABLE. Closes #85.
+3. **Backend: rebase PRs #112/#113/#114/#115** onto current main (all CONFLICTING after wave merges), then Programmer merges each. Closes #89, #87, #90, #88.
+4. **Programmer: verify PR #110** — issue #86 already closed; confirm oci-block-storage not already in main; close #110 if duplicate, otherwise Backend rebases.
+5. **Programmer: merge yage-docs PR #5** — ADR 0004 Phase G. Closes #81.
+6. **Programmer: merge yage-docs PR #6** — ADR 0009 Phase H. Closes #121.
+7. **Backend: start #118** (p1) — D1: wire `csi.Selector` into orchestrator; delete `internal/capi/csi/`. Unblocked once CSI PRs land.
 
 ### Planned (next sprint)
 
-5. **Issue #71** (p2, Backend) — ADR 0002 item 7: remove redundant `cfg.InfraProvider == "proxmox"` guards.
-6. **Issue #80** (p3, Backend) — OpenStack EnsureIdentity: template clouds.yaml. **Blocked** on ADR 0004 acceptance (yage-docs PR #5).
-7. **Issue #79** (p3, Backend) — vSphere PatchManifest sizing fields.
+8. **Issue #71** (p2, Backend) — ADR 0002 item 7: remove redundant `cfg.InfraProvider == "proxmox"` guards.
+9. **Issue #80** (p3, Backend) — OpenStack EnsureIdentity: template clouds.yaml. **Blocked** on PR #5 merge.
+10. **Issue #79** (p3, Backend) — vSphere PatchManifest sizing fields.
 
 ### Backlog
 
-8. **Issue #119** (p3, Backend) — D4: CAPD smoke E2E test for bootstrap pipeline.
-9. **Issues #94–#101** (p3, Backend) — 8 PlanDescriber provider implementations (epic #78).
+11. **Issue #119** (p3, Backend) — D4: CAPD smoke E2E test for bootstrap pipeline.
+12. **Issues #94–#101** (p3, Backend) — 8 PlanDescriber provider implementations (epic #78).
 
 ---
 

--- a/docs/context/agents/PO.md
+++ b/docs/context/agents/PO.md
@@ -19,6 +19,17 @@ You are the Product Owner for the yage project. You own the backlog, track deliv
 3. Update "Active Work" table to reflect current branch/issue state.
 4. Update "Next Steps" and "Known Issues" if anything changed.
 5. If a new epic or feature area emerged from the merged work, open tracking issues and add them to "Active Work".
+6. For each open issue or piece of work that needs doing, record a handoff entry in CURRENT_STATE.md naming the correct agent and the exact task — then stop. Do not do the work yourself.
+
+## Handoff protocol
+
+When you find work that needs doing, write a handoff record in CURRENT_STATE.md under "Active Work":
+
+```
+| issue-or-branch | Agent: <yage-backend/yage-frontend/yage-architect/yage-platform-engineer> | <one-line task description> | waiting |
+```
+
+Then report back to the user with a list of handoffs. The user will launch the appropriate agents. You never perform implementation, code review, or git operations beyond reading state.
 
 ## GitHub conventions
 
@@ -29,7 +40,9 @@ You are the Product Owner for the yage project. You own the backlog, track deliv
 
 ## What you do NOT do
 
-- Do not write or review Go code.
+- **Never write, edit, or review code** — not Go, not YAML, not shell scripts. If you find yourself about to touch a `.go` file, stop and create a handoff instead.
+- **Never run git commands that change state** — no `git checkout`, `git rebase`, `git merge`, `git push`, `git stash`. Read-only git commands (`git log`, `git status`, `git diff`) are fine.
+- **Never merge or close PRs** via `gh pr merge`. Record the PR as needing merge in CURRENT_STATE.md and hand off to the Programmer agent.
 - Do not make architecture decisions — escalate to the Architect.
 - Do not refine implementation details — escalate to Platform Engineer or Backend.
 - Do not commit to yage-docs/docs/context/AGENT_SYSTEM_PROMPT.md without Architect sign-off.


### PR DESCRIPTION
## Summary

- Add ADR 0009: on-prem platform services — bootstrap registry + online issuing CA via OpenTofu (Phase H)
- Design: OpenTofu-provisioned Proxmox VMs via \`yage-tofu/registry/\` and \`yage-tofu/issuing-ca/\` modules (same Fetcher+Runner pattern as ADR 0004)
- Explicit: offline root CA boundary unchanged; KubeVirt rejected for bootstrap use; image seeding deferred to follow-up

Closes lpasquali/yage#121

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 3 Checklist

- [x] \`mkdocs build --strict\` passes
- [x] \`pymarkdown scan README.md docs\` passes (no Markdown lint errors)

## Audit Checks

No triggers fired. This is a documentation-only change: no Go code modified, no \`go.mod\` changed, no CI workflows modified, no Secret schemas changed, no CAPI YAML patching.

## Acceptance Criteria Evidence

- [x] \`mkdocs build --strict\` — INFO: Documentation built in 1.11 seconds (no ERRORs, no WARNINGs)
- [x] ADR covers all six required sections (registry, bootstrap sequence, issuing CA, offline CA boundary, registry HA, KubeVirt rejection)

## Breaking Changes

None.