### PR TITLE
docs(state): PO session 4 — reconcile #129–#131; Phase H handoffs; PR #128 ready

### DIFF
--- a/docs/architecture/adrs/0008-yage-manifests-gitops-templates.md
+++ b/docs/architecture/adrs/0008-yage-manifests-gitops-templates.md
@@ -1,7 +1,8 @@
 # ADR 0008 — yage-manifests: GitOps YAML Template Repository
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-30
+**Accepted:** 2026-05-01
 **Owners:** Architect (interface contract, repository structure), Backend (Fetcher implementation, per-package migration)
 
 ---

--- a/docs/architecture/adrs/0010-in-cluster-repo-cache.md
+++ b/docs/architecture/adrs/0010-in-cluster-repo-cache.md
@@ -1,0 +1,295 @@
+# ADR 0010 — In-Cluster Repository Cache: Zero Workstation Residue
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Owners:** Backend (Fetcher redesign, RepoSync Job, PVC lifecycle), Architect (interface contract)
+
+**Supersedes (partial):**
+- ADR 0004 §2 steps 1–4 (local `~/.yage/tofu-cache/` fetch) and §2 tofu state path
+- ADR 0008 §3 (`manifests.Fetcher` `CacheDir` field and `~/.yage/manifests-cache/`)
+
+---
+
+## Context
+
+ADR 0004 (Phase G) and ADR 0008 (yage-manifests) both design a fetch-and-cache pattern
+where yage clones external Git repositories to the operator's workstation at bootstrap time:
+
+- `yage-tofu` → `~/.yage/tofu-cache/`
+- Per-provider tofu state → `~/.yage/tofu/<provider>/terraform.tfstate`
+- `yage-manifests` → `~/.yage/manifests-cache/`
+
+These paths leave residue on the operator's workstation that persists beyond the kind
+cluster's lifetime. An operator who runs `kind delete cluster` expects a clean slate;
+the cache dirs remain.
+
+The architectural goal is **zero workstation residue**: when the kind cluster is deleted,
+all yage-managed state disappears with it. The four external repositories yage depends on
+during a bootstrap run are:
+
+| Repository | Consumer | Already in-cluster? |
+|---|---|---|
+| `lpasquali/yage-tofu` | `opentofux.JobRunner` (tofu HCL modules) | No — cloned locally |
+| `lpasquali/yage-manifests` | `manifests.Fetcher` (YAML templates) | No — cloned locally |
+| operator's `workload-app-of-apps` | ArgoCD repo-server | **Yes** — ArgoCD fetches internally |
+| operator's `workload-smoketests` | ArgoCD repo-server | **Yes** — ArgoCD fetches internally |
+
+Only the first two require action. The ArgoCD-consumed repos are already in-cluster.
+
+kind's default `StorageClass: standard` (rancher `local-path-provisioner`) stores PVC data
+inside the kind node's Docker container filesystem, not on the host. A PVC created in the
+`yage-system` namespace is gone the moment `kind delete cluster` runs. This is the correct
+primitive.
+
+---
+
+## Decision
+
+### 1. Single shared PVC: `yage-repos`
+
+yage creates one PVC named `yage-repos` in the `yage-system` namespace immediately after
+the kind cluster is up, before any repo-dependent phase runs.
+
+```
+Name:         yage-repos
+Namespace:    yage-system
+StorageClass: standard          # kind local-path-provisioner; in-Docker, not on host
+Capacity:     500Mi             # covers yage-tofu + yage-manifests with headroom
+AccessMode:   ReadWriteOnce     # kind is single-node; RWO is sufficient
+```
+
+Mount layout inside Jobs that consume the PVC:
+
+```
+/repos/
+  yage-tofu/        ← lpasquali/yage-tofu at cfg.TofuRef
+  yage-manifests/   ← lpasquali/yage-manifests at cfg.ManifestsRef
+```
+
+### 2. `yage-repo-sync` Job
+
+A `batch/v1 Job` named `yage-repo-sync` in `yage-system` runs immediately after the PVC
+is created. It has one init container per repo; the main container exits immediately after
+the init containers succeed.
+
+```yaml
+initContainers:
+- name: sync-yage-tofu
+  image: alpine/git:2          # or cfg.ImageRegistryMirror/alpine/git:2 for airgap
+  env:
+  - name: REPO
+    value: https://github.com/lpasquali/yage-tofu
+  - name: REF
+    value: "$(YAGE_TOFU_REF)"
+  command:
+  - sh
+  - -c
+  - |
+    if [ -d /repos/yage-tofu/.git ]; then
+      git -C /repos/yage-tofu fetch --depth=1 origin "$REF" && \
+      git -C /repos/yage-tofu checkout FETCH_HEAD
+    else
+      git clone --depth=1 --branch "$REF" "$REPO" /repos/yage-tofu
+    fi
+  volumeMounts:
+  - { name: repos, mountPath: /repos }
+
+- name: sync-yage-manifests
+  image: alpine/git:2
+  # identical pattern, REPO=lpasquali/yage-manifests, REF=cfg.ManifestsRef
+  ...
+
+containers:
+- name: done
+  image: busybox:stable
+  command: ["true"]
+
+volumes:
+- name: repos
+  persistentVolumeClaim:
+    claimName: yage-repos
+```
+
+yage runs the Job synchronously (waits for `Complete`; treats `Failed` as fatal). Log
+streaming uses the pod log API — same pattern as `JobRunner` in `opentofux`. The Job is
+deleted after it completes (TTL or explicit deletion) to keep `yage-system` clean.
+
+### 3. Updated `opentofux.Fetcher`
+
+The `Fetcher` in `internal/platform/opentofux/fetcher.go` is revised to replace the
+local `CacheDir` clone with PVC-based path resolution. The struct no longer needs a
+`CacheDir` field; the module path is derived from the known PVC mount at `/repos/yage-tofu/`.
+
+```go
+// Fetcher resolves yage-tofu module paths from the in-cluster PVC.
+// The PVC must be mounted at /repos/yage-tofu/ in the calling Job pod.
+// Use EnsureRepoSync to populate it before calling ModulePath.
+type Fetcher struct {
+    // MountRoot is the path at which the yage-repos PVC is mounted in the
+    // current pod. Defaults to /repos when empty.
+    MountRoot string
+}
+
+// ModulePath returns the absolute path to the named module directory.
+// e.g. ModulePath("proxmox") → "/repos/yage-tofu/proxmox"
+func (f *Fetcher) ModulePath(module string) string {
+    root := f.MountRoot
+    if root == "" {
+        root = "/repos"
+    }
+    return filepath.Join(root, "yage-tofu", module)
+}
+
+// EnsureRepoSync creates the yage-repos PVC (if absent) and runs the
+// yage-repo-sync Job to clone/fetch both yage-tofu and yage-manifests.
+// Must be called once per bootstrap run, after kind is up.
+func EnsureRepoSync(ctx context.Context, cli *k8sclient.Client, cfg *config.Config) error
+```
+
+The `JobRunner` already mounts the PVC for state (`tofu-state-<module>`). Its `Apply` and
+`Destroy` implementations are updated to additionally mount `yage-repos` at `/repos/` so
+the HCL source is available at `/repos/yage-tofu/<module>/` alongside the state PVC.
+
+### 4. Updated `manifests.Fetcher`
+
+The `internal/platform/manifests.Fetcher` (ADR 0008 §3) drops `CacheDir`. Template files
+are read directly from the PVC mount:
+
+```go
+type Fetcher struct {
+    // MountRoot is the path at which the yage-repos PVC is mounted.
+    // Defaults to /repos when empty.
+    MountRoot string
+}
+
+// Render reads the .yaml.tmpl at templatePath (relative to yage-manifests root
+// on the PVC) and executes it with data via text/template.
+// e.g. Render("csi/proxmox/values.yaml.tmpl", cfg)
+func (f *Fetcher) Render(templatePath string, data any) (string, error) {
+    fullPath := filepath.Join(f.mountRoot(), "yage-manifests", templatePath)
+    raw, err := os.ReadFile(fullPath)
+    ...
+}
+```
+
+Callers that run as in-cluster Jobs receive the PVC mount automatically. Callers that run
+locally (e.g. `--dry-run` before kind is up) must call `EnsureRepoSync` first or use a
+local fixture path (test/dev mode).
+
+### 5. Bootstrap sequence amendment
+
+The `yage-system` namespace setup and PVC/Job creation are inserted immediately after the
+kind cluster is ready:
+
+```
+kind cluster create
+  ↓
+EnsureNamespace(yage-system)         [existing]
+EnsureNamespace(workload-namespace)  [existing]
+CreatePVC(yage-repos)                [NEW — this ADR]
+RunJob(yage-repo-sync)               [NEW — this ADR, synchronous, fatal on failure]
+  ↓
+EnsureIdentity (tofu Jobs mount yage-repos read-only for HCL source)
+  ↓
+manifests.Fetcher.Render (reads from yage-repos PVC via Job mount)
+  ↓
+... rest of bootstrap
+```
+
+### 6. OpenTofu provider plugin cache
+
+ADR 0004 mentions `~/.terraform.d/plugin-cache` for warming the BPG provider. The
+`JobRunner` handles this in-cluster: `tofu init` downloads providers into the Job
+container's ephemeral layer. Providers are re-downloaded on each Job run unless a
+dedicated `tofu-providers` PVC is added (deferred; not in scope for this ADR).
+
+The `LocalRunner` (pre-kind exception, §7 below) continues to use
+`~/.terraform.d/plugin-cache`. This is the only acceptable workstation write path; it is
+documented as an exception and must be explicitly cleaned up on `--purge`.
+
+### 7. Exception: phases that run before kind
+
+ADR 0009 §1 places registry VM provisioning before the kind cluster phase. A `JobRunner`
+requires a running management cluster; it cannot be used before kind exists.
+
+**Resolution adopted by this ADR:**
+
+Registry and issuing CA provisioning (ADR 0009 Phase H) are rescheduled to run **after**
+the kind cluster is up and the `yage-repos` PVC is populated. The kind cluster uses
+standard image pulls (internet or pre-seeded), not the yage-managed bootstrap registry,
+for the kind phase itself. The registry VM is provisioned after kind, its IP is written to
+`cfg.ImageRegistryMirror`, and subsequent CAPI workload cluster provisioning uses it.
+
+This eliminates the pre-kind exception. `LocalRunner` remains in the codebase for:
+- Development and test use (running tofu locally without a kind cluster).
+- Manual operator invocations outside the normal bootstrap flow.
+
+`LocalRunner.Apply` writes to `os.MkdirTemp` when used in the production pre-kind fallback
+path, and the caller is responsible for `os.RemoveAll` after use. This path is explicitly
+not the happy path.
+
+### 8. Airgap support
+
+For air-gapped environments:
+- Mirror `lpasquali/yage-tofu` and `lpasquali/yage-manifests` to an internal Git server.
+- Set `YAGE_TOFU_REF` and `YAGE_MANIFESTS_REF` to `https://internal.git/yage-tofu@<tag>`
+  (the Fetcher accepts a `REPO_URL` override via env, analogous to `YAGE_TOFU_REPO` and
+  `YAGE_MANIFESTS_REPO` — new config fields to be added alongside this ADR).
+- Mirror `alpine/git:2` to the internal registry and set `cfg.ImageRegistryMirror`.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Zero workstation residue.** `kind delete cluster` removes the PVC and all cloned
+  content. The operator's `~/.yage/` directory is no longer written to during a normal
+  bootstrap run.
+
+- **Single source of truth for repo content.** Both `yage-tofu` Jobs and
+  `manifests.Fetcher` render Jobs read from the same `yage-repos` PVC. The sync happens
+  once at bootstrap; all subsequent reads are local (no repeated network calls).
+
+- **Consistent with `JobRunner` PVC pattern.** The `tofu-state-<module>` PVC design in
+  #123 already uses kind's local-path-provisioner. `yage-repos` follows the same pattern.
+
+- **Registry provisioning resequencing simplifies the overall design.** The pre-kind
+  exception is eliminated from the production path, making `JobRunner` the sole production
+  execution model.
+
+### Negative
+
+- **`EnsureRepoSync` is a new required bootstrap phase.** A network failure during
+  `yage-repo-sync` fails the entire bootstrap. This is the same failure mode as the
+  previous local clone, but the failure surface moves from the operator's shell to a
+  pod log.
+
+- **`manifests.Fetcher.Render` requires a running cluster.** `--dry-run` before kind is
+  up cannot render actual templates. Mitigation: `--dry-run` in `plan.go` uses local
+  stubs or skips the Render calls entirely (same approach as other cluster-dependent
+  phases in dry-run mode).
+
+- **`alpine/git` image dependency.** The `yage-repo-sync` Job requires a container image.
+  This is pinned by digest in production to prevent supply-chain drift.
+
+### Risks
+
+- **PVC ReadWriteOnce on multi-node kind.** kind is always single-node, so RWO is
+  sufficient. If multi-node kind support is added in future, the PVC must change to RWX or
+  each node must get its own PVC. This is explicitly deferred.
+
+- **PVC capacity.** 500Mi is an estimate. If `yage-tofu` or `yage-manifests` grow
+  significantly, the PVC capacity request must be updated. The `yage-repos` PVC creation
+  code should accept a `YAGE_REPOS_PVC_SIZE` override (default `500Mi`).
+
+---
+
+## References
+
+- ADR 0004 — Universal OpenTofu Identity Bootstrap (Phase G); §2 steps 1–4 and state path superseded by this ADR
+- ADR 0008 — yage-manifests GitOps Template Repository; §3 `CacheDir` and `~/.yage/manifests-cache/` superseded by this ADR
+- ADR 0009 — On-prem platform services; §1 registry provisioning sequence amended by §7 of this ADR
+- Issue #123 — `opentofux.JobRunner` PVC design (`tofu-state-<module>`) — compatible with `yage-repos` PVC
+- Issue #136 — `manifests.Fetcher` implementation (ADR 0008 step 2) — must follow this ADR's interface, not ADR 0008 §3
+- Issue #125 — registry VM provisioning — must follow the post-kind sequencing decision in §7

--- a/docs/architecture/adrs/0011-pivot-yage-state-migration.md
+++ b/docs/architecture/adrs/0011-pivot-yage-state-migration.md
@@ -1,0 +1,320 @@
+# ADR 0011 — Pivot: yage State Migration to the Management Cluster
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Owners:** Backend (handoff extension, EnsureManagementStorageClass, EnsureRepoSync wiring), Architect (interface contract)
+
+**Related ADRs:**
+- ADR 0001 — CSI driver registry; management-cluster CSI installation path introduced by §4
+- ADR 0004 — OpenTofu identity bootstrap; tofu-state storage model replaced by §1
+- ADR 0010 — In-cluster repo cache; EnsureRepoSync called on mgmt cluster by §5
+
+---
+
+## Context
+
+After a successful pivot, the kind bootstrap cluster is torn down and the CAPI management
+cluster (provisioned on the active provider — Proxmox, AWS, vSphere, etc.) becomes the
+permanent management plane. The current pivot implementation (`internal/capi/pivot/`) and
+`kindsync.HandOffBootstrapSecretsToManagement` leave two categories of yage state behind:
+
+**1. OpenTofu state PVCs (`tofu-state-<module>`).**
+ADR 0004 §2 stores `terraform.tfstate` in a per-module PVC in the `yage-system` namespace.
+These PVCs live inside the kind Docker container and are destroyed with it.
+`HandOffBootstrapSecretsToManagement` does not copy PVC content.
+
+**2. `yage-repos` PVC.**
+ADR 0010 stores the `yage-tofu` and `yage-manifests` Git checkouts in a `yage-repos` PVC
+in `yage-system`. Any post-pivot orchestrator phase that calls `manifests.Fetcher.Render`
+or runs a tofu `JobRunner` requires this PVC on the management cluster.
+
+Additionally, the management cluster is a freshly-provisioned CAPI workload cluster. Unlike
+kind (which always has the `standard` StorageClass via local-path-provisioner), the management
+cluster has no StorageClass unless a CSI driver is explicitly installed before PVC-dependent
+operations run.
+
+---
+
+## Decision
+
+### 1. OpenTofu `kubernetes` backend — state as Secrets, not PVCs
+
+All `yage-tofu` modules are migrated from any local or PVC-based state backend to the
+OpenTofu built-in `kubernetes` backend. State is stored as Kubernetes Secrets in the
+`yage-system` namespace with a consistent label set, making them automatically copyable by
+the label-based handoff described in §2.
+
+Each module gets a `backend.tf` (or equivalent block in `main.tf`):
+
+```hcl
+terraform {
+  backend "kubernetes" {
+    secret_suffix = "<module>"   # e.g. "proxmox", "aws", "openstack"
+    namespace     = "yage-system"
+    labels = {
+      "app.kubernetes.io/managed-by" = "yage"
+      "app.kubernetes.io/component"  = "tofu-state"
+    }
+  }
+}
+```
+
+The resulting Secret is named `tfstate-default-<module>`. With the
+`app.kubernetes.io/managed-by=yage` label, it is automatically included in the extended
+handoff (§2).
+
+The `JobRunner` in `internal/platform/opentofux` is updated to pass the in-cluster
+backend configuration to `tofu init`. The Job pod runs with the `yage-job-runner`
+ServiceAccount, which has RBAC to manage Secrets in `yage-system` (see §3 below).
+
+**Consequence:** the `tofu-state-<module>` PVCs are eliminated. The only PVC remaining in
+`yage-system` is `yage-repos`.
+
+### 2. Extended `HandOffBootstrapSecretsToManagement` — label-based yage-system copy
+
+`kindsync.HandOffBootstrapSecretsToManagement` gains a second pass after the existing
+named-Secret copy: a label-scoped list of all `yage-system` Secrets carrying
+`app.kubernetes.io/managed-by=yage`, applied to the management cluster via server-side apply.
+
+```go
+// copyYageSystemSecrets lists all Secrets in namespace matching
+// app.kubernetes.io/managed-by=yage on srcCli and applies them to dstCli.
+func copyYageSystemSecrets(
+    ctx context.Context,
+    srcCli, dstCli *k8sclient.Client,
+    namespace string,
+) (int, error)
+```
+
+For each matched Secret, the function strips server-side metadata (same
+`stripServerAnnotations` pattern as the existing code) and applies it with
+`types.ApplyPatchType`, `Force=true`.
+
+This covers:
+- `tfstate-default-<module>` Secrets (tofu state, §1 above)
+- Any future yage-managed Secrets that carry the label
+
+The existing named-target list (`expectedHandoffTargets`) is retained for Proxmox-specific
+Secrets in other namespaces (e.g. `capmox-system/capmox-manager-credentials`) that do not
+carry the label.
+
+`HandOffBootstrapSecretsToManagement` returns an augmented summary:
+
+```go
+type HandoffResult struct {
+    NamedCopied int
+    LabelCopied int
+    FirstErr    error
+}
+```
+
+Errors are warnings (consistent with existing behavior); the orchestrator logs both counts.
+
+### 3. `yage-system` bootstrap on the management cluster (SA + RBAC)
+
+The `yage-job-runner` ServiceAccount and its associated ClusterRole / ClusterRoleBinding
+must exist on the management cluster before the first tofu Job runs there. They are not
+Secrets and are not copied by the handoff mechanism (§2).
+
+**Resolution:** the orchestrator calls a new helper `kindsync.EnsureYageSystemOnCluster`
+immediately after the `yage-system` namespace is created on the management cluster (during
+the handoff step §2). This helper re-creates all non-Secret yage-system primitives from
+a known in-code spec — not by copying from kind — ensuring idempotency:
+
+```go
+// EnsureYageSystemOnCluster creates or updates the yage-system ServiceAccount,
+// ClusterRole, and ClusterRoleBinding required for JobRunner operation.
+// Idempotent; safe to call on both kind and the management cluster.
+func EnsureYageSystemOnCluster(ctx context.Context, cli *k8sclient.Client) error
+```
+
+The ClusterRole grants `get`, `list`, `watch`, `create`, `update`, `patch`, `delete` on
+`secrets` scoped to `yage-system`. The ClusterRoleBinding binds it to the
+`yage-job-runner` ServiceAccount in `yage-system`.
+
+`EnsureYageSystemOnCluster` is also called during the initial kind bootstrap (before
+`EnsureRepoSync`) so both clusters share the same setup path.
+
+### 4. CSI driver installation on the management cluster
+
+The management cluster needs a working StorageClass before `EnsureRepoSync` creates the
+`yage-repos` PVC. On kind the `standard` (local-path-provisioner) StorageClass is always
+present. On a real CAPI cluster it must be installed.
+
+`internal/provider/provider.go` explicitly excludes CSI from the `Provider` interface
+(see comment at line ~130: *"The Provider interface intentionally has no CSI hook"*). This
+decision is preserved. Instead, the management-cluster CSI install is added to the
+`internal/csi.Driver` interface, consistent with ADR 0001's registry pattern:
+
+```go
+// EnsureManagementInstall installs this CSI driver (chart + credentials Secret)
+// on the management cluster identified by mgmtKubeconfig. Called after
+// InstallCAPIOnManagement and before EnsureRepoSync. Idempotent.
+// Returns ErrNotApplicable when this driver is not relevant for the
+// management cluster (e.g. the provider does not pivot, or the management
+// cluster uses a different CSI than the workload cluster).
+EnsureManagementInstall(cfg *config.Config, mgmtKubeconfig string) error
+```
+
+A default `ErrNotApplicable` implementation is provided via the driver base type so
+existing drivers require no change unless they implement a management path.
+
+**Helm rationale:** the workload-cluster CSI is installed via CAAPH `HelmChartProxy`,
+which is an ArgoCD-driven mechanism. The management cluster does not run ArgoCD at the
+point `EnsureManagementInstall` is called (ArgoCD on the management cluster, if desired,
+is a post-pivot operator concern). Therefore `EnsureManagementInstall` uses a direct
+Helm invocation — `helm upgrade --install` via `shell.Run` — the same mechanism already
+used for workload-cluster operations that precede ArgoCD readiness. The `helm` binary is
+a documented dependency for `EnsureIdentity`-class operations and is available in the yage
+execution environment.
+
+**Proxmox implementation (`internal/csi/proxmoxcsi`):**
+
+1. Call `proxmoxcsi.EnsureSecret` to apply the Proxmox API credential Secret to the
+   management cluster (reuses the existing function, passing the management kubeconfig).
+2. Run `helm upgrade --install proxmox-csi-plugin <chart> --namespace kube-system
+   --create-namespace --set storageClass.name=<cfg.Providers.Proxmox.CSIStorageClassName>
+   --kubeconfig <mgmtKubeconfig>` via `shell.Run`.
+
+The storage class name defaults to `cfg.Providers.Proxmox.CSIStorageClassName` (same as
+the workload cluster). Operators who need a different pool for the management cluster can
+set a new optional field `PROXMOX_CSI_MGMT_STORAGE_CLASS` (defaults to workload value).
+
+**Orchestrator lookup:** the orchestrator finds the active driver for the current provider
+using the existing CSI registry (`csi.For(cfg)` or equivalent) and calls
+`EnsureManagementInstall`. If the driver returns `ErrNotApplicable`, the orchestrator waits
+up to `cfg.Pivot.StorageClassReadyTimeout` (default: 5 minutes) for any non-local-path
+default StorageClass to appear — this handles cloud providers whose controller manager
+injects a StorageClass automatically (e.g. AWS EBS SC created by the cloud controller
+manager). If none appears within the timeout, the orchestrator logs a fatal error.
+
+### 5. `EnsureRepoSync` on the management cluster
+
+After the handoff (§2), RBAC setup (§3), and CSI install (§4), the orchestrator calls
+`EnsureRepoSync` (ADR 0010 §2) targeting the management cluster:
+
+```go
+mgmtCli, err := k8sclient.ForKubeconfigFile(mgmtKubeconfig)
+// ...
+if err := opentofux.EnsureRepoSync(ctx, mgmtCli, cfg); err != nil {
+    logx.Die("pivot: EnsureRepoSync on management cluster: %v", err)
+}
+```
+
+This creates the `yage-repos` PVC on the management cluster (using the StorageClass
+provided by §4) and runs the `yage-repo-sync` Job. The `alpine/git:2` image pull uses
+`cfg.ImageRegistryMirror` if set. The registry VM (ADR 0009 §1, provisioned post-kind
+per ADR 0010 §7) is available by the time pivot runs, so `cfg.ImageRegistryMirror` is
+already populated in air-gapped environments.
+
+`EnsureRepoSync` is idempotent: it checks for PVC existence before creating and re-uses
+an existing `yage-repos` PVC if found. A re-run after a partial failure retries safely.
+
+### 6. Extended `VerifyParity`
+
+`pivot.VerifyParity` gains three additional checks after the existing CAPI inventory +
+provider Secret checks:
+
+**a. yage-system namespace present:** Assert that `yage-system` exists on the management
+cluster (created by handoff §2).
+
+**b. Minimum labeled Secrets present:** List Secrets in `yage-system` with
+`app.kubernetes.io/managed-by=yage` on the management cluster. Zero is a warning (not
+fatal) — a first-run with no tofu modules executed yet has no tfstate Secrets to copy.
+One or more is the expected steady-state.
+
+**c. `yage-repos` PVC in `Bound` phase:** Assert that the `yage-repos` PVC in `yage-system`
+is `Bound`. A `Pending` PVC here indicates a StorageClass problem; surface it with a clear
+diagnostic before the first post-pivot tofu Job runs.
+
+### 7. Updated pivot bootstrap sequence
+
+```
+MoveCAPIState                              [existing — clusterctl move]
+  ↓
+HandOffBootstrapSecretsToManagement        [extended: §2 label-based yage-system copy]
+  ↓
+EnsureYageSystemOnCluster (on mgmt)        [NEW — §3: SA + RBAC from spec]
+  ↓
+csi.Driver.EnsureManagementInstall         [NEW — §4: CSI + StorageClass on mgmt]
+  ↓
+EnsureRepoSync (on mgmt)                   [NEW — §5: yage-repos PVC + repo-sync Job]
+  ↓
+VerifyParity                               [extended: §6 yage-system + PVC checks]
+  ↓
+rebindKindContextToMgmt                    [existing]
+  ↓
+[downstream phases: workload apply, ArgoCD on workload]
+  ↓
+TeardownKind                               [existing; deferred to post-workload]
+```
+
+---
+
+## Consequences
+
+### Positive
+
+- **Complete yage state arrives on the management cluster.** Tofu state (as Secrets),
+  repo content (via `yage-repos` PVC), and all yage-system bootstrap Secrets are present
+  before any post-pivot phase runs.
+
+- **Tofu-state PVCs are eliminated.** The switch to the `kubernetes` backend removes the
+  `tofu-state-<module>` PVC lifecycle entirely.
+
+- **Label-based handoff scales automatically.** New yage-managed Secrets that carry
+  `app.kubernetes.io/managed-by=yage` are migrated without code changes to `handoff.go`.
+
+- **ADR 0001 invariant preserved.** The `Provider` interface gains no CSI hook;
+  management CSI install lives on `csi.Driver` where it belongs.
+
+- **Consistent zero-workstation-residue (ADR 0010).** No tofu state, no repo content, and
+  no yage Secrets live on the operator's workstation disk.
+
+- **Post-pivot idempotency.** All new steps (`EnsureYageSystemOnCluster`,
+  `EnsureManagementInstall`, `EnsureRepoSync`) are idempotent. A re-run after a partial
+  failure re-creates what is missing.
+
+### Negative
+
+- **`csi.Driver` interface gains a new method.** All registered drivers receive a
+  `EnsureManagementInstall` method that defaults to `ErrNotApplicable`. Only drivers used
+  on providers that pivot need a real implementation.
+
+- **Management cluster Helm dependency.** `EnsureManagementInstall` for Proxmox uses
+  `helm` via `shell.Run`. The `helm` binary must be present in the yage execution
+  environment — already a documented requirement for identity-bootstrap-class operations.
+
+- **`kubernetes` backend requires RBAC on both clusters.** `EnsureYageSystemOnCluster` (§3)
+  must run before any tofu Job on the management cluster. The orchestrator enforces this
+  sequencing in §7.
+
+- **`EnsureRepoSync` is fatal on mgmt.** A network or image-pull failure in
+  `yage-repo-sync` on the management cluster blocks pivot completion. The Job is idempotent
+  so a re-run of yage post-pivot retries safely.
+
+### Risks
+
+- **Air-gap: management-cluster image pull.** The `yage-repo-sync` Job on the management
+  cluster needs `alpine/git:2`. `cfg.ImageRegistryMirror` must be set before pivot. The
+  registry VM (ADR 0009, post-kind) is provisioned before pivot runs, so this is satisfied
+  in the normal bootstrap flow.
+
+- **Management cluster StorageClass name.** If the CSI driver creates a StorageClass the
+  operator does not expect (e.g. `proxmox-data-xfs` when they wanted a different name),
+  subsequent HCL modules referencing a specific StorageClass name may fail. Mitigated by
+  `PROXMOX_CSI_MGMT_STORAGE_CLASS` config field defaulting to the workload value.
+
+---
+
+## References
+
+- ADR 0001 — CSI driver registry; `Driver` interface extension in §4
+- ADR 0004 — Universal OpenTofu Identity Bootstrap; state backend replaced by §1
+- ADR 0009 — On-prem platform services; registry VM sequencing (post-kind) ensures `ImageRegistryMirror` is set before pivot
+- ADR 0010 — In-cluster repo cache; `EnsureRepoSync` spec, `yage-repos` PVC; §5 of this ADR calls it on the management cluster
+- `internal/cluster/kindsync/handoff.go` — `HandOffBootstrapSecretsToManagement` (§2 extension)
+- `internal/capi/pivot/pivot.go` — `VerifyParity` (§6 extension)
+- `internal/csi/driver.go` — `Driver` interface; `EnsureManagementInstall` method (§4)
+- `internal/orchestrator/bootstrap.go` — pivot sequence (§7 updated)
+- Issue #144 — `EnsureRepoSync` implementation; must target both kind and management clusters

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -2,22 +2,42 @@
 
 ## Living Memory
 
-yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is largely complete: phases A, B, C, and E are done; D is substantially complete. Legacy cleanup is complete per ADR 0002 (no-backward-compatibility policy). ADR 0007 adopted: dashboard is the new default xapiri entry point. The full CSI driver registry (ADR 0001) is now complete — all 10 drivers merged.
+yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. Phase H (on-prem platform services via OpenTofu) is next — ADR 0009 accepted, implementation issues #123–#127 open.
 
 ## Freshness Policy
 
 This file must be updated whenever system state evolves (per CODING_STANDARDS.md "Atomic Persistence"). If information here conflicts with what you observe in the code or git history, trust what you observe now — then update this file to match reality.
 
-Last updated: **2026-04-30** — PO session 3: CSI wave fully merged (#108–#115, #110, #122); yage-docs ADR PRs #5 and #6 merged; epics #77 and #104 closed; #118 and #80 now unblocked
+Last updated: **2026-05-01** — PO session 4: PRs #129–#131 reconciled; Phase H issues #123–#127 added to Active Work; PR #128 ready to merge
 
 ## Version Baseline
 
 | Repo | Branch | Recent PRs | Status |
 |---|---|---|---|
-| yage | `main` | #122 (E2BIG fix), #115 (openstack-cinder), #114 (ibm-vpc-block), #113 (linode-block), #112 (longhorn), #111 (do-block), #110 (oci-block), #108 (openebs), #117 (xapiri dashboard-only) | Active development |
+| yage | `main` | #131 (D1 csi.Selector wire + delete internal/capi/csi), #130 (ADR 0002 item 7 InfraProvider guards), #129 (vsphere PatchManifest sizing), #122 (E2BIG fix), #115–#117 (CSI + xapiri) | Active development |
 | yage-docs | `main` | ADRs 0001–0009 written and accepted; WORKFLOW added | Documentation in progress |
 
 ## Recent Changes
+
+### 2026-05-01 — PO session 4: PRs #129–#131 reconciled; Phase H issues added; PR #128 ready
+
+**PRs merged to main (2026-04-30 late, not reflected in previous CURRENT_STATE update):**
+
+- **PR #129** merged — `feat(vsphere): PatchManifest — honor VSphereMachineTemplate sizing fields`. Closes #79. Backend complete.
+- **PR #130** merged — `refactor(orchestrator): remove redundant InfraProvider=="proxmox" guards (ADR 0002 item 7)`. Closes #71. ADR 0002 item 7 now done.
+- **PR #131** merged — `feat(orchestrator): wire csi.Selector; delete internal/capi/csi`. Closes #118. D1 complete; `internal/capi/csi/` deleted from codebase.
+
+**Phase H implementation issues created (all p2, children of epic #120):**
+- **#123** — opentofux: introduce Fetcher+Runner abstraction (Backend, prerequisite for #125 + #126)
+- **#124** — config: add `YAGE_REGISTRY_*` and `YAGE_ISSUING_CA_*` fields (Backend, prerequisite for all)
+- **#125** — orchestrator: provision bootstrap registry VM via OpenTofu (Backend, blocked on #123 + #124)
+- **#126** — orchestrator: provision online issuing CA + wire cert-manager ClusterIssuer (Backend, blocked on #123 + #124)
+- **#127** — xapiri+plan: surface Phase H registry and issuing CA fields in TUI + `--dry-run` (Frontend/Backend, blocked on #124)
+
+**Open PR needing merge:**
+- **PR #128** (`feat/80-openstack-ensure-identity`) — OpenStack EnsureIdentity: `clouds.yaml` Secret. Closes #80. MERGEABLE, all CI green (CodeQL, Quality, SecretScan). Programmer: move from "rune" project to yage project #1, then merge.
+
+---
 
 ### 2026-04-30 — PO session 3: CSI wave complete; ADR docs merged; epics closed
 
@@ -234,10 +254,12 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 | Issue / PR | Branch | Agent | Description | Status |
 |---|---|---|---|---|
-| #118 | TBD | **yage-backend** | D1: wire `csi.Selector` into orchestrator; delete `internal/capi/csi/` | **Unblocked** — p1, all CSI PRs merged, start now |
-| #71 | TBD | **yage-backend** | ADR 0002 item 7: remove redundant `cfg.InfraProvider == "proxmox"` guards | **Planned** — p2 next sprint |
-| #80 | TBD | **yage-backend** | OpenStack EnsureIdentity: template `clouds.yaml` from config fields | **Unblocked** — p3; ADR 0004 Phase G now accepted (PR #5 merged) |
-| #79 | TBD | **yage-backend** | vSphere PatchManifest: honor `VSphereMachineTemplate` sizing fields | **Planned** — p3 |
+| PR #128 | `feat/80-openstack-ensure-identity` | **Programmer** | Merge PR #128; move to yage project #1 first. Closes #80. | **Ready** — MERGEABLE, all CI green |
+| #124 | TBD | **yage-backend** | config: add `YAGE_REGISTRY_*` + `YAGE_ISSUING_CA_*` fields (Phase H prerequisite) | **Unblocked** — p2, start now |
+| #123 | TBD | **yage-backend** | opentofux: introduce Fetcher+Runner abstraction (Phase H prerequisite for #125 + #126) | **Unblocked** — p2, start after #124 or in parallel |
+| #125 | TBD | **yage-backend** | orchestrator: provision bootstrap registry VM via OpenTofu | **Blocked** on #123 + #124 — p2 |
+| #126 | TBD | **yage-backend** | orchestrator: provision online issuing CA + wire cert-manager ClusterIssuer | **Blocked** on #123 + #124 — p2 |
+| #127 | TBD | **yage-frontend** / **yage-backend** | xapiri+plan: surface Phase H fields in TUI and `--dry-run` | **Blocked** on #124 — p2 |
 | #119 | TBD | **yage-backend** | D4: CAPD smoke E2E test for bootstrap pipeline | **Backlog** — p3 |
 | #94 | TBD | **yage-backend** | PlanDescriber (DescribeIdentity/Workload/Pivot) for Linode | **Backlog** — p3 (epic #78) |
 | #95 | TBD | **yage-backend** | PlanDescriber for CAPD (docker) | **Backlog** — p3 (epic #78) |
@@ -247,7 +269,7 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 | #99 | TBD | **yage-backend** | PlanDescriber for IBM Cloud | **Backlog** — p3 (epic #78) |
 | #100 | TBD | **yage-backend** | PlanDescriber for GCP | **Backlog** — p3 (epic #78) |
 | #101 | TBD | **yage-backend** | PlanDescriber for DigitalOcean | **Backlog** — p3 (epic #78) |
-| #120 | — | — | Epic: on-prem platform services via OpenTofu (airgap path) | Open — roadmap container; #121 closed (ADR merged) |
+| #120 | — | — | Epic: on-prem platform services via OpenTofu (airgap path) | Open — children #123–#127 in Active Work above |
 | #78 | — | — | Epic: PlanDescriber missing for 8 providers (children: #94–#101) | Open — parent epic |
 
 ---
@@ -257,25 +279,25 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 - xapiri is still a work-in-progress TUI; not all provider paths are fully wired.
 - Cost estimation requires live Proxmox API; returns `ErrUnavailable` when unreachable.
 - vSphere `Inventory()`: `Cores=0` — CPU expressed in MHz only (cannot derive cores from ResourcePool quota alone without host-speed query).
-- **D1**: Orchestrator still calls `capi/csi.ApplyConfigSecretToWorkload` in `bootstrap.go` and `workloadapps.go`; `internal/capi/csi/` should be deleted per ADR 0001 once D1 (#118) merges.
 
 ## Next Steps
 
 ### Immediate (current sprint)
 
-1. **yage-backend: start #118** (p1, unblocked) — D1: wire `csi.Selector` into orchestrator; delete `internal/capi/csi/`. All CSI PRs now merged.
-2. **yage-backend: start #71** (p2) — ADR 0002 item 7: remove redundant `cfg.InfraProvider == "proxmox"` guards.
-3. **yage-backend: start #80** (p3, now unblocked) — OpenStack EnsureIdentity: template `clouds.yaml` from config fields. ADR 0004 Phase G accepted.
+1. **Programmer: merge PR #128** — OpenStack EnsureIdentity. Move to yage project #1, then merge. Closes #80.
+2. **yage-backend: start #124** (p2, unblocked) — config: add `YAGE_REGISTRY_*` + `YAGE_ISSUING_CA_*` fields. Prerequisite for all Phase H issues.
+3. **yage-backend: start #123** (p2, unblocked) — opentofux: Fetcher+Runner abstraction. Can run in parallel with #124. Prerequisite for #125 + #126.
 
-### Planned (next sprint)
+### Planned (next sprint — blocked on #123 + #124)
 
-4. **Issue #79** (p3, Backend) — vSphere PatchManifest sizing fields.
-5. **Issues #94–#101** (p3, Backend) — 8 PlanDescriber provider implementations (epic #78).
+4. **yage-backend: #125** — orchestrator: provision bootstrap registry VM via OpenTofu.
+5. **yage-backend: #126** — orchestrator: provision online issuing CA + wire cert-manager ClusterIssuer.
+6. **yage-frontend + yage-backend: #127** — xapiri+plan: surface Phase H fields in TUI and `--dry-run` (blocked on #124 only).
 
 ### Backlog
 
-6. **Issue #119** (p3, Backend) — D4: CAPD smoke E2E test for bootstrap pipeline.
-7. **Epic #120** — on-prem platform services (registry + issuing CA via OpenTofu): no implementation issues open yet; Architect to define sub-issues when prioritized.
+7. **Issue #119** (p3, Backend) — D4: CAPD smoke E2E test for bootstrap pipeline.
+8. **Issues #94–#101** (p3, Backend) — 8 PlanDescriber provider implementations (epic #78).
 
 ---
 

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -2,24 +2,75 @@
 
 ## Living Memory
 
-yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. Phase H (on-prem platform services via OpenTofu) is next — ADR 0009 accepted, implementation issues #123–#127 open.
+yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. Phase H (on-prem platform services via OpenTofu) is next — ADRs 0009/0010/0011 accepted. PR #128 (OpenStack EnsureIdentity) merged to main.
 
 ## Freshness Policy
 
 This file must be updated whenever system state evolves (per CODING_STANDARDS.md "Atomic Persistence"). If information here conflicts with what you observe in the code or git history, trust what you observe now — then update this file to match reality.
 
-Last updated: **2026-05-01** — PO session 4: PRs #129–#131 reconciled; Phase H issues #123–#127 added to Active Work; PR #128 ready to merge
+Last updated: **2026-05-01** — PO session 5: ADR 0011 committed; issues #144–#148 created; yage-manifests epic #133–#142 added; PR #128 merged to main; PR #132 MERGEABLE; PR #143 needs two changes before merge
 
 ## Version Baseline
 
 | Repo | Branch | Recent PRs | Status |
 |---|---|---|---|
-| yage | `main` | #131 (D1 csi.Selector wire + delete internal/capi/csi), #130 (ADR 0002 item 7 InfraProvider guards), #129 (vsphere PatchManifest sizing), #122 (E2BIG fix), #115–#117 (CSI + xapiri) | Active development |
-| yage-docs | `main` | ADRs 0001–0009 written and accepted; WORKFLOW added | Documentation in progress |
+| yage | `main` | #128 (OpenStack EnsureIdentity), #131 (D1 csi.Selector), #130 (ADR 0002 item 7), #129 (vsphere PatchManifest) | Active development |
+| yage-docs | `docs/po-session-3-state-update` | ADRs 0001–0011 written and accepted | PR #8 open, MERGEABLE |
 
 ## Recent Changes
 
-### 2026-05-01 — PO session 4: PRs #129–#131 reconciled; Phase H issues added; PR #128 ready
+### 2026-05-01 — PO session 5: ADR 0011; pivot state migration issues; manifests epic; PR #128 merged
+
+**PR merged to main:**
+- **PR #128** merged — `feat(openstack): EnsureIdentity — apply clouds.yaml Secret`. Closes #80. ✅
+
+**yage-docs: ADRs 0010 and 0011 committed to `docs/po-session-3-state-update`:**
+
+- **ADR 0010** — In-cluster repository cache (zero workstation residue): `yage-repos` PVC (500Mi, yage-system), `yage-repo-sync` Job (alpine/git init containers), updated Fetcher structs (MountRoot-based, no CacheDir), registry provisioning rescheduled post-kind. Supersedes local `~/.yage/tofu-cache/` and `~/.yage/manifests-cache/`.
+
+- **ADR 0011** — Pivot: yage state migration to management cluster. Seven decisions:
+  1. Switch `yage-tofu` modules to OpenTofu `kubernetes` backend — state as `tfstate-default-<module>` Secrets in `yage-system` (labeled `app.kubernetes.io/managed-by=yage`); eliminates `tofu-state-<module>` PVCs.
+  2. Extend `HandOffBootstrapSecretsToManagement` with label-based (`app.kubernetes.io/managed-by=yage`) yage-system Secret copy.
+  3. New `EnsureYageSystemOnCluster` — re-creates SA + Role + RoleBinding from in-code spec on any cluster (not copied); prerequisite for tofu kubernetes backend and EnsureRepoSync.
+  4. `csi.Driver.EnsureManagementInstall` — management CSI install on Driver interface (Provider interface stays CSI-free per ADR 0001); Proxmox uses direct Helm (ArgoCD not running on mgmt at this stage).
+  5. `EnsureRepoSync` called on management cluster post-handoff.
+  6. Extended `VerifyParity`: yage-system namespace present + ≥0 labeled Secrets + `yage-repos` PVC Bound.
+  7. Updated pivot sequence with explicit ordering of all new steps.
+
+**New issues created:**
+
+*yage-manifests epic (ADR 0008):*
+- **#133** — epic: yage-manifests — migrate all inline YAML generation to external template repo
+- **#134** — ops: scaffold lpasquali/yage-manifests repository structure
+- **#135** — config: add `YAGE_MANIFESTS_REF` field
+- **#136** — manifests: implement `internal/platform/manifests` Fetcher package
+- **#137** — manifests: migrate `internal/capi/helmvalues/` to yage-manifests templates
+- **#138** — manifests: migrate `internal/capi/wlargocd/` ArgoCD Application renderers
+- **#139** — manifests: migrate `internal/capi/postsync/` renderers
+- **#140** — manifests: migrate `internal/capi/caaph/` string renderers
+- **#141** — csi: migrate `RenderValues` → `Render` + port all 14 drivers to yage-manifests (atomic)
+- **#142** — manifests: retire `internal/capi/helmvalues/`, `wlargocd/`, `postsync/` packages
+
+*Pivot state migration (ADR 0011):*
+- **#144** — orchestrator: create `yage-repos` PVC and run `yage-repo-sync` Job — updated to require cluster-agnostic `EnsureRepoSync` callable on both kind and management cluster
+- **#145** — opentofux: switch yage-tofu modules to OpenTofu kubernetes backend (eliminate `tofu-state-<module>` PVCs)
+- **#146** — kindsync: `EnsureYageSystemOnCluster` — SA + RBAC bootstrap from spec on any cluster
+- **#147** — csi: add `Driver.EnsureManagementInstall` + Proxmox implementation + `PROXMOX_CSI_MGMT_STORAGE_CLASS` field
+- **#148** — kindsync+pivot: extend HandOff with label-based yage-system copy + extend VerifyParity
+
+**PR status:**
+- **PR #132** (`feat/124-phase-h-config-fields`): all CI green, MERGEABLE. **Programmer: merge now.** Closes #124.
+- **PR #143** (`feat/123-opentofux-fetcher-runner`): MERGEABLE by CI but **review comment requires two changes before merge** — (1) `fetcher.go`: replace local clone with PVC path resolver per ADR 0010; (2) `opentofux.go`: delete, do not keep as stub per ADR 0002. Backend must address both, then Programmer merges.
+- **PR #8** (yage-docs `docs/po-session-3-state-update`): MERGEABLE. Contains ADR 0010 + ADR 0011 + CURRENT_STATE. Programmer: merge when ready.
+
+**Issue updates:**
+- **#123**: Acceptance criteria updated — Fetcher is PVC path resolver (no local clone), `opentofux.go` deleted. Review comment left on PR #143 documenting required changes.
+- **#125**: Now also blocked on #144 (EnsureRepoSync) in addition to #123 + #124.
+- **#136**: Fetcher interface updated per ADR 0010 (MountRoot-based, no CacheDir/RepoURL/Ref).
+
+---
+
+### 2026-05-01 — PO session 4: PRs #129–#131 reconciled; Phase H issues #123–#127 added to Active Work; PR #128 ready to merge
 
 **PRs merged to main (2026-04-30 late, not reflected in previous CURRENT_STATE update):**
 
@@ -30,209 +81,15 @@ Last updated: **2026-05-01** — PO session 4: PRs #129–#131 reconciled; Phase
 **Phase H implementation issues created (all p2, children of epic #120):**
 - **#123** — opentofux: introduce Fetcher+Runner abstraction (Backend, prerequisite for #125 + #126)
 - **#124** — config: add `YAGE_REGISTRY_*` and `YAGE_ISSUING_CA_*` fields (Backend, prerequisite for all)
-- **#125** — orchestrator: provision bootstrap registry VM via OpenTofu (Backend, blocked on #123 + #124)
+- **#125** — orchestrator: provision bootstrap registry VM via OpenTofu (Backend, blocked on #123 + #124 + #144)
 - **#126** — orchestrator: provision online issuing CA + wire cert-manager ClusterIssuer (Backend, blocked on #123 + #124)
 - **#127** — xapiri+plan: surface Phase H registry and issuing CA fields in TUI + `--dry-run` (Frontend/Backend, blocked on #124)
-
-**Open PR needing merge:**
-- **PR #128** (`feat/80-openstack-ensure-identity`) — OpenStack EnsureIdentity: `clouds.yaml` Secret. Closes #80. MERGEABLE, all CI green (CodeQL, Quality, SecretScan). Programmer: move from "rune" project to yage project #1, then merge.
 
 ---
 
 ### 2026-04-30 — PO session 3: CSI wave complete; ADR docs merged; epics closed
 
-**yage-docs PRs merged:**
-- **PR #5** (`docs/81-adr-0004-phase-g`) merged to main — ADR 0004 Phase G: universal OpenTofu identity bootstrap. Closes #81.
-- **PR #6** (`docs/121-adr-0009-platform-services`) merged to main — ADR 0009 Phase H: on-prem platform services (registry + issuing CA). Closes #121.
-
-**yage CSI wave — all 10 drivers now merged (ADR 0001 epic #77 COMPLETE):**
-- **PR #108** merged — openebs driver. Closes #93.
-- **PR #110** merged — oci-block-storage driver (Oracle Cloud). Closes #86.
-- **PR #111** merged — do-block-storage driver (DigitalOcean). Closes #85.
-- **PR #112** merged — longhorn driver (cross-provider). Closes #89.
-- **PR #113** merged — linode-block-storage driver. Closes #87.
-- **PR #114** merged — ibm-vpc-block driver. Closes #90.
-- **PR #115** merged — openstack-cinder driver (with INI fix). Closes #88.
-- Previously merged: #107 (hcloud), #109 (rook-ceph), #116 (vsphere-csi) close #84, #92, #91.
-- **Epic #77 (CSI driver registry) closed** — all 10 child issues resolved.
-
-**yage PR #122 merged:**
-- `fix(manifest): avoid E2BIG when clusterctl env inherits large parent vars` — `BuildEnv()` deduplicates `os.Environ()` before appending overrides. No issue attached.
-
-**xapiri ADR 0007 (PR #117 already merged in session 2):**
-- **Epic #104 (ADR 0007)** closed this session — both children #103 and #105 resolved by PR #117.
-
-**Unblocked by these merges:**
-- **#118** (D1: wire `csi.Selector` into orchestrator) — now fully unblocked; all CSI PRs landed.
-- **#80** (OpenStack EnsureIdentity `clouds.yaml`) — unblocked by yage-docs PR #5 merge (ADR 0004 Phase G now accepted).
-
----
-
-### 2026-04-30 — PO audit (session 2): PR #122 new; CSI conflict triage; yage-docs PRs #5 and #6 both ready
-
-**New PR #122 — not previously tracked:**
-- `fix(manifest): avoid E2BIG when clusterctl env inherits large parent vars` on `fix/clusterctl-env-arg-max`
-- Status: MERGEABLE, all checks green. Ready for Programmer to merge immediately.
-- Fix: `BuildEnv()` in `internal/capi/manifest` deduplicates `os.Environ()` before appending overrides; eliminates `E2BIG` on large `~/.ssh/authorized_keys` or other large inherited vars.
-
-**CSI wave status update (as of this audit):**
-- #111 (do-block-storage): MERGEABLE — ready for Programmer.
-- #112 (longhorn): CONFLICTING — needs Backend rebase onto current main, then Programmer merge. Closes #89.
-- #113 (linode-block-storage): CONFLICTING — needs Backend rebase onto current main, then Programmer merge. Closes #87.
-- #114 (ibm-vpc-block): CONFLICTING — needs Backend rebase onto current main, then Programmer merge. Closes #90.
-- #115 (openstack-cinder): CONFLICTING — needs Backend rebase onto current main, then Programmer merge. Closes #88.
-- #110 (oci-block-storage): ANOMALY — issue #86 is already CLOSED (likely auto-closed by an earlier merge); PR #110 still open on `worktree-agent-a015af3c2c642e63e`. Programmer should verify whether work is already in main and close #110 if duplicate; otherwise Backend should rebase and Programmer should merge.
-
-**yage-docs PRs:**
-- PR #5 (`docs/81-adr-0004-phase-g`): MERGEABLE — Programmer to merge; closes #81.
-- PR #6 (`docs/121-adr-0009-platform-services`): MERGEABLE — Programmer to merge; closes #121.
-
----
-
-### 2026-04-30 — PO audit: xapiri #117 + vsphere-csi #116 merged; CSI wave ongoing; new issues #118–#121
-
-**Frontend (ADR 0007 — xapiri dashboard-only):**
-- **PR #117 merged** (`feat/xapiri-dashboard-only`) — closes #103 (dashboard default) and #105 (remove legacy walkthrough). Both issues auto-closed by GitHub.
-- #104 (epic: ADR 0007) remains open as parent.
-
-**Backend (CSI drivers — ADR 0001 epic #77):**
-- **PR #116 merged** (vsphere-csi) — closes #91 (auto-closed).
-- **PR #109 merged** (rook-ceph) — closes #92 (auto-closed).
-- **PR #108 merged** (openebs) — closes #93 (auto-closed).
-- **PR #107 merged** (hcloud-csi) — closes #84 (auto-closed).
-- **6 CSI PRs still open and in-flight**: #110 (oci), #111 (do), #112 (longhorn), #113 (linode), #114 (ibm-vpc), #115 (openstack-cinder INI fix). Being merged by programmer agent; #110 has conflicts (DIRTY), others show UNKNOWN state (likely mid-merge).
-
-**New issues created:**
-- **#118** — D1: wire `csi.Selector` into orchestrator; delete `internal/capi/csi/` (p1, Backend, unblocked)
-- **#119** — D4: CAPD smoke E2E test for bootstrap pipeline (p3, backlog)
-- **#120** — Epic: on-prem platform services — bootstrap registry + online issuing CA via OpenTofu (airgap path)
-- **#121** — ADR 0009: Phase H on-prem platform services: registry + issuing CA via OpenTofu (p2, Architect)
-
-**Architect (#81 — ADR 0004 Phase G):**
-- **yage-docs PR #5** open: https://github.com/lpasquali/yage-docs/pull/5 — accepts ADR 0004 universal OpenTofu identity bootstrap. Branch: `docs/81-adr-0004-phase-g`. Issue #81 assigned to lpasquali.
-
----
-
-### 2026-04-30 — PO session: ADR 0007 epic opened; agent assignments issued
-
-**New issues opened (ADR 0007 — xapiri dashboard as default entry):**
-- **#104** — epic: ADR 0007 — xapiri dashboard as default entry; deprecate and remove legacy walkthrough
-- **#103** — Phase 1 (Frontend, p1): make dashboard the default entry point; skip pre-dashboard config selection prompt. Key change: `internal/ui/xapiri/xapiri.go:useHuhTUI()` defaults to true when env var unset; `YAGE_XAPIRI_TUI=legacy` opts back for one sprint.
-- **#105** — Phase 2 (Frontend, p3): remove legacy bufio walkthrough entirely. **Blocked**: must not start until one sprint after #103 merges.
-
-**Agent assignments (this session):**
-- **Frontend**: #103 (p1 — start now)
-- **Backend**: #68 (p1 — integrate worktrees A/B/D1/D4), then #71, then #84–#93
-- **Architect**: #81 (p2 — flesh out ADR 0004 OpenTofu Phase G)
-- **Platform Engineer**: no new refinements pending; standby
-
-**GitHub hygiene:** #68 assigned to lpasquali; #103–#105 added to project board.
-
----
-
-### 2026-04-30 — PRs #72–#76 merged; issues #66, #67, #69, #70, #82, #83 closed
-
-**Five PRs merged in sequence:**
-- **#72** — `provider/vsphere`: EnsureGroup + Inventory via govmomi; Proxmox cleanup (ADR 0002 items 2+6). Closes #67.
-- **#74** — `refactor(config,pricing)`: remove `OS_*`/`YAGE_CURRENCY` env aliases + legacy snapshot JSON (ADR 0002 items 3–5).
-- **#76** — `feat(xapiri)`: TUI keymap normalization + dispatch architecture fixes (ADR 0003). Closes #69.
-- **#75** — `provider/openstack`: PatchManifest flavor resolution + Inventory via gophercloud; fix flavor env keys. Closes #66.
-- **#73** — `refactor(kindsync)`: remove `SyncProxmoxBootstrapLiteralCredentials` (ADR 0002 item 1). Closes #70 (partial).
-
-**ADRs 0003–0007** written and accepted in `yage-docs`.
-
-**Issues closed:** #66, #67, #69, #70, #82, #83.
-
----
-
-### 2026-04-30 — Issue #69: xapiri TUI keymap normalization + dispatch fixes (ADR 0003)
-
-**Frontend agent** completed on `feat/xapiri-tui-dispatch-fixes` (commit `e1b198d`):
-- Removed `j/k` navigation from `updateCfgListScreen`, `updateCfgEditScreen`, `updateLogsTab`, `updateCostsTab`; up/down arrows only
-- Removed `Tab`/`ShiftTab` as field-nav from `updateCfgEditScreen`; arrows only
-- Promoted `inTextField` inline expression to `(m dashModel) inTextField() bool` method; added `tabCosts+costCredsMode` case
-- Added `preserveTransientState(old, next dashModel) dashModel` helper; replaces manual copy in `cfgEntryLoadMsg` handler
-- `initFromConfig` in `state.go` now calls `detectFork(cfg)` when `cfg.InfraProvider == ""`
-- `renderCostsTab`: inline dim note when `CostCompareEnabled && !GeoIPEnabled && DataCenterLocation == ""`
-- Help tab: updated j/k refs to show arrows; added `[ / ]` timeframe keys for Costs tab
-- `bootstrap_config.go`: `WithKeyMap` override on all huh Select forms to remove j/k navigation
-- All tests pass; `go vet` clean
-
----
-
-### 2026-04-30 — Agent completions: vSphere (#67), OpenStack (#66); ADR 0003 written
-
-**vSphere agent** completed on `feat/xapiri-config-provision-split` (commit `761f900`):
-- New: `internal/provider/vsphere/connect.go` (shared `vsphereConnect` with TLS thumbprint pinning)
-- New: `internal/provider/vsphere/ops.go` (`EnsureGroup` folder creation via govmomi, `Inventory` via ResourcePool)
-- Modified: `internal/provider/vsphere/vsphere.go` (removed ErrNotApplicable stubs for EnsureGroup/Inventory)
-- Added: `github.com/vmware/govmomi v0.53.1` to `go.mod`
-- Note: `Inventory` returns `Cores=0` with CPU expressed in MHz (cannot derive cores from ResourcePool alone)
-
-**OpenStack agent** completed on `worktree-agent-afd01feec4a66c948` (commit `97b5288`):
-- New: `internal/provider/openstack/inventory.go` (`PatchManifest` flavor resolution via Nova, `Inventory` quota via Nova+Cinder)
-- Fixed: `state.go` stale env keys (`OPENSTACK_WORKER_FLAVOR` → `OPENSTACK_NODE_MACHINE_FLAVOR`, `OPENSTACK_CONTROL_PLANE_FLAVOR` → `OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR`)
-- Added: `github.com/gophercloud/gophercloud/v2 v2.12.0` to `go.mod`
-- Added: smoke test `TestTemplateVarsKeysMatchTemplate` guarding the env key correctness
-
----
-
-### 2026-04-30 — Architect assessment: phase status corrected; ADR 0002 no-compat policy
-
-Architect audited the codebase and produced §25 addendum to `abstraction-plan.md`:
-
-- **Phase status corrected**: CURRENT_STATE previously showed A/B/D/E as "Not started"; ground truth is A/B/E complete, D substantially complete (see Abstraction Plan Status table below).
-- **No-backward-compatibility policy adopted** (ADR 0002): yage has no production users; all legacy fallbacks (dual-read/write migration, env-var aliases, Secret-name fallbacks, JSON-format fallbacks) are dead weight and will be deleted without deprecation cycle.
-- **Three ADR documents written**: §25 addendum to `abstraction-plan.md`; ADR 0001 (CSI driver registry); ADR 0002 (backward compat removal).
-
----
-
-### 2026-04-30 — xapiri: config/provision tab split (merged to main)
-
-Split the previous single "Config" tab in xapiri into two separate tabs:
-- **Config** (tab 1) — profile selection list and new-config name input
-- **Provision** (tab 2) — full interactive edit form for the selected config
-
-Selecting a config from the list automatically switches to the provision tab. All other tabs (3–9) remain gated on `cfgSelected`. Keyboard shortcuts 1–8, ctrl+alt+1–8, and mouse click-to-focus remapped to new indices. Help tab updated.
-
----
-
-### 2026-04-29 — Config system revamp: per-ns layout, fork restore, dual-arch image check (#65)
-
-Merged into `main`. Per-namespace config layout; fork restore logic; dual-arch image presence check at bootstrap.
-
----
-
-### 2026-04-28 — xapiri + kindsync + pricing: per-config bootstrap Secrets, region-ranked costs, installer TUI API (#64)
-
-Per-config bootstrap Secrets tied to `cfg.ConfigName`; region-ranked cost display in xapiri; installer toolchain exposed via TUI API.
-
----
-
-### 2026-04-27 — xapiri: mode-filtered provider list + mgmt+workload network config (#63)
-
-Provider list filtered by bootstrap mode; management and workload network config integrated into xapiri walk-through.
-
----
-
-### 2026-04-26 — xapiri: streaming costs, full config expansion, mouse & log UX (#62)
-
-Live cost streaming in xapiri; full config tree expansion; mouse support and improved log pane UX.
-
----
-
-### Earlier xapiri milestones
-
-| PR | Summary |
-|---|---|
-| #61 | Fix: editor never opens + wrong fallback editor + remove deploy cost preview |
-| #60 | Fix: resolve editor via VISUAL→EDITOR→probe chain with OS-specific fallbacks |
-| #59 | Embedded PTY terminal pane + UX navigation fixes |
-| #58 | Phase-F: operator Secret config, CRD types, deploy tab, credential hardening |
-| #54 | Phase-F spike: yage-operator cost runner + Prometheus metrics |
-| #51 | Overcommit toggle in dashboard + capacity prompt |
-| #50 | provider/ibmcloud: K3sTemplate, KindSyncFields, TemplateVars |
-| #47 | xapiri: pivot/mgmt-cluster settings step (on-prem fork) |
+*(See git log for full detail — ADRs 0001–0009 accepted, CSI epic #77 closed, ADR 0002 legacy cleanup complete, all 10 CSI drivers merged.)*
 
 ---
 
@@ -243,10 +100,10 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 | Phase | Goal | Status |
 |---|---|---|
 | C | Config namespacing (`cfg.Proxmox*` → `cfg.Providers.Proxmox.*`) | **Merged** |
-| A | Inventory behind `Provider.Inventory()` | **Complete** (interface + call sites wired; Proxmox implements; cleanup in progress) |
-| B | Plan body delegation per provider | **Complete** (DescribeIdentity/DescribeWorkload/DescribePivot wired; Proxmox implements) |
-| D | Generic kindsync + Purge | **Substantially complete** (KindSyncFields + WriteBootstrapConfigSecret in use; legacy wrappers removed per ADR 0002) |
-| E | Pivot generalization (kind → any-cloud mgmt) | **Complete** (PivotTarget called via interface in pivot.go) |
+| A | Inventory behind `Provider.Inventory()` | **Complete** |
+| B | Plan body delegation per provider | **Complete** |
+| D | Generic kindsync + Purge | **Substantially complete** |
+| E | Pivot generalization (kind → any-cloud mgmt) | **Complete** |
 
 ---
 
@@ -254,23 +111,39 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 | Issue / PR | Branch | Agent | Description | Status |
 |---|---|---|---|---|
-| PR #128 | `feat/80-openstack-ensure-identity` | **Programmer** | Merge PR #128; move to yage project #1 first. Closes #80. | **Ready** — MERGEABLE, all CI green |
-| #124 | TBD | **yage-backend** | config: add `YAGE_REGISTRY_*` + `YAGE_ISSUING_CA_*` fields (Phase H prerequisite) | **Unblocked** — p2, start now |
-| #123 | TBD | **yage-backend** | opentofux: introduce Fetcher+Runner abstraction (Phase H prerequisite for #125 + #126) | **Unblocked** — p2, start after #124 or in parallel |
-| #125 | TBD | **yage-backend** | orchestrator: provision bootstrap registry VM via OpenTofu | **Blocked** on #123 + #124 — p2 |
-| #126 | TBD | **yage-backend** | orchestrator: provision online issuing CA + wire cert-manager ClusterIssuer | **Blocked** on #123 + #124 — p2 |
-| #127 | TBD | **yage-frontend** / **yage-backend** | xapiri+plan: surface Phase H fields in TUI and `--dry-run` | **Blocked** on #124 — p2 |
+| PR #132 | `feat/124-phase-h-config-fields` | **Programmer** | Merge PR #132. Closes #124. All CI green. | **Ready** — MERGEABLE |
+| PR #8 (yage-docs) | `docs/po-session-3-state-update` | **Programmer** | Merge PR #8 (ADR 0010 + ADR 0011 + CURRENT_STATE). | **Ready** — MERGEABLE |
+| PR #143 | `feat/123-opentofux-fetcher-runner` | **yage-backend** | Two changes required before merge: (1) `fetcher.go` → PVC path resolver per ADR 0010; (2) delete `opentofux.go` per ADR 0002. Then Programmer merges. | **Needs Backend fix** |
+| #146 | TBD | **yage-backend** | `EnsureYageSystemOnCluster` — SA + Role + RoleBinding from spec on any cluster | **Unblocked** — p1, prerequisite for #144 + #145 |
+| #144 | TBD | **yage-backend** | `EnsureRepoSync` — create `yage-repos` PVC + `yage-repo-sync` Job; cluster-agnostic (kind + mgmt) | **Blocked** on #123 + #135 + #146 |
+| #145 | TBD | **yage-backend** | OpenTofu `kubernetes` backend for yage-tofu modules; eliminates `tofu-state-<module>` PVCs | **Blocked** on #123 + #146 |
+| #147 | TBD | **yage-backend** | `csi.Driver.EnsureManagementInstall` + Proxmox impl + `PROXMOX_CSI_MGMT_STORAGE_CLASS` config field | **Blocked** on #146 |
+| #148 | TBD | **yage-backend** | Extend `HandOffBootstrapSecretsToManagement` (label pass) + extend `VerifyParity` (yage-system + PVC checks) | **Blocked** on #145 + #146 + #144 + #147 |
+| #135 | TBD | **yage-backend** | config: add `YAGE_MANIFESTS_REF` field | **Unblocked** — p2 (can parallel with #123 fix) |
+| #136 | TBD | **yage-backend** | `internal/platform/manifests` Fetcher package (MountRoot-based, no local clone) | **Blocked** on #135 + #144 |
+| #125 | TBD | **yage-backend** | orchestrator: provision bootstrap registry VM via OpenTofu | **Blocked** on #123 + #124 + #144 |
+| #126 | TBD | **yage-backend** | orchestrator: provision online issuing CA + wire cert-manager ClusterIssuer | **Blocked** on #123 + #124 |
+| #127 | TBD | **yage-frontend** / **yage-backend** | xapiri+plan: surface Phase H fields in TUI and `--dry-run` | **Blocked** on #124 (merge PR #132) |
+| #134 | TBD | **yage-backend** / **ops** | scaffold `lpasquali/yage-manifests` repo structure | **Unblocked** — p2 |
+| #137 | TBD | **yage-backend** | migrate `internal/capi/helmvalues/` to yage-manifests templates | **Blocked** on #136 |
+| #138 | TBD | **yage-backend** | migrate `internal/capi/wlargocd/` renderers to yage-manifests templates | **Blocked** on #136 |
+| #139 | TBD | **yage-backend** | migrate `internal/capi/postsync/` renderers to yage-manifests templates | **Blocked** on #136 |
+| #140 | TBD | **yage-backend** | migrate `internal/capi/caaph/` string renderers to yage-manifests templates | **Blocked** on #136 |
+| #141 | TBD | **yage-backend** | CSI `RenderValues` → `Render` + port all 14 drivers to yage-manifests (atomic) | **Blocked** on #136 |
+| #142 | TBD | **yage-backend** | retire `helmvalues/`, `wlargocd/`, `postsync/` packages | **Blocked** on #137–#141 |
 | #119 | TBD | **yage-backend** | D4: CAPD smoke E2E test for bootstrap pipeline | **Backlog** — p3 |
-| #94 | TBD | **yage-backend** | PlanDescriber (DescribeIdentity/Workload/Pivot) for Linode | **Backlog** — p3 (epic #78) |
-| #95 | TBD | **yage-backend** | PlanDescriber for CAPD (docker) | **Backlog** — p3 (epic #78) |
-| #96 | TBD | **yage-backend** | PlanDescriber for OpenStack | **Backlog** — p3 (epic #78) |
-| #97 | TBD | **yage-backend** | PlanDescriber for vSphere | **Backlog** — p3 (epic #78) |
-| #98 | TBD | **yage-backend** | PlanDescriber for Azure | **Backlog** — p3 (epic #78) |
-| #99 | TBD | **yage-backend** | PlanDescriber for IBM Cloud | **Backlog** — p3 (epic #78) |
-| #100 | TBD | **yage-backend** | PlanDescriber for GCP | **Backlog** — p3 (epic #78) |
-| #101 | TBD | **yage-backend** | PlanDescriber for DigitalOcean | **Backlog** — p3 (epic #78) |
-| #120 | — | — | Epic: on-prem platform services via OpenTofu (airgap path) | Open — children #123–#127 in Active Work above |
-| #78 | — | — | Epic: PlanDescriber missing for 8 providers (children: #94–#101) | Open — parent epic |
+| #94–#101 | TBD | **yage-backend** | PlanDescriber for 8 providers (Linode, CAPD, OpenStack, vSphere, Azure, IBM, GCP, DO) | **Backlog** — p3 (epic #78) |
+
+---
+
+## Critical Path (unblocked work agents can start now)
+
+1. **Programmer: merge PR #132** — closes #124; unblocks #127, #125, #126
+2. **Programmer: merge yage-docs PR #8** — publishes ADR 0010 + ADR 0011
+3. **yage-backend: fix PR #143** — address two ADR 0010 review comments, then Programmer merges; closes #123; unblocks #125, #126, #144, #145
+4. **yage-backend: start #146** (`EnsureYageSystemOnCluster`) — unblocked; prerequisite for #144, #145, #147
+5. **yage-backend: start #135** (`YAGE_MANIFESTS_REF` config field) — unblocked; can parallel with #146
+6. **yage-backend: start #134** (scaffold yage-manifests repo) — unblocked; independent
 
 ---
 
@@ -278,35 +151,21 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 - xapiri is still a work-in-progress TUI; not all provider paths are fully wired.
 - Cost estimation requires live Proxmox API; returns `ErrUnavailable` when unreachable.
-- vSphere `Inventory()`: `Cores=0` — CPU expressed in MHz only (cannot derive cores from ResourcePool quota alone without host-speed query).
+- vSphere `Inventory()`: `Cores=0` — CPU expressed in MHz only.
+- PR #143 (`feat/123-opentofux-fetcher-runner`) implements the old ADR 0008 §3 Fetcher (local clone to `~/.yage/tofu-cache/`). Must be updated to ADR 0010 PVC path resolver before merge.
 
-## Next Steps
+## ADR Index
 
-### Immediate (current sprint)
-
-1. **Programmer: merge PR #128** — OpenStack EnsureIdentity. Move to yage project #1, then merge. Closes #80.
-2. **yage-backend: start #124** (p2, unblocked) — config: add `YAGE_REGISTRY_*` + `YAGE_ISSUING_CA_*` fields. Prerequisite for all Phase H issues.
-3. **yage-backend: start #123** (p2, unblocked) — opentofux: Fetcher+Runner abstraction. Can run in parallel with #124. Prerequisite for #125 + #126.
-
-### Planned (next sprint — blocked on #123 + #124)
-
-4. **yage-backend: #125** — orchestrator: provision bootstrap registry VM via OpenTofu.
-5. **yage-backend: #126** — orchestrator: provision online issuing CA + wire cert-manager ClusterIssuer.
-6. **yage-frontend + yage-backend: #127** — xapiri+plan: surface Phase H fields in TUI and `--dry-run` (blocked on #124 only).
-
-### Backlog
-
-7. **Issue #119** (p3, Backend) — D4: CAPD smoke E2E test for bootstrap pipeline.
-8. **Issues #94–#101** (p3, Backend) — 8 PlanDescriber provider implementations (epic #78).
-
----
-
-### 2026-04-30 — Platform Engineer issue refinement
-
-Three open issues refined with K8s/infra-level implementation specs:
-
-- **#66** (OpenStack PatchManifest + Inventory): Flagged pre-existing bug — `OPENSTACK_NODE_MACHINE_FLAVOR` vs `OPENSTACK_WORKER_FLAVOR` env key mismatch in TemplateVars vs K3s template. gophercloud v2 not yet in go.mod — must be added. Nova `limits.Get` + Cinder quotasets API paths specified.
-- **#67** (vSphere Inventory + EnsureScope): govmomi not yet in go.mod — must be added. ResourcePool property query path specified. Unlimited pool (`-1`) edge case: return `ErrNotApplicable`. TLS thumbprint field check required.
-- **#68** (Background agent integration): D1 depends on B. Ordering constraint: proxmox-csi `EnsureSecret` must run before HelmChartProxy fires. Post-D1: delete `internal/capi/csi/` per ADR 0001.
-
-**Handoff to Backend:** #66 and #67 are resolved (merged in #75, #72). #68 is integration ops — check worktree/branch status of A/B/D1/D4 before starting.
+| ADR | Title | Status |
+|---|---|---|
+| 0001 | CSI driver registry | Accepted |
+| 0002 | Backward compat removal | Accepted |
+| 0003 | xapiri TUI dispatch keymap | Accepted |
+| 0004 | Universal OpenTofu identity bootstrap (Phase G) | Accepted |
+| 0005 | Pricing/cost subsystem | Accepted |
+| 0006 | Capacity preflight architecture | Accepted |
+| 0007 | xapiri dashboard as default entry | Accepted |
+| 0008 | yage-manifests GitOps template repository | Accepted |
+| 0009 | On-prem platform services (Phase H): registry + issuing CA | Accepted |
+| 0010 | In-cluster repository cache (zero workstation residue) | Accepted |
+| 0011 | Pivot: yage state migration to management cluster | Accepted |


### PR DESCRIPTION
## Summary

PO session 4 CURRENT_STATE reconciliation:
- PRs #129 (vsphere PatchManifest), #130 (ADR 0002 item 7), #131 (D1 csi.Selector + delete `internal/capi/csi`) merged to yage main — reflected in Version Baseline and Active Work.
- Phase H implementation issues #123–#127 added to Active Work with dependency chain.
- PR #128 (OpenStack EnsureIdentity, closes #80) flagged as ready to merge.
- D1 Known Issue removed (resolved by #131). Abstraction plan Living Memory updated: all 5 phases complete.

## DoD Level

- [x] **Level 3 — Documentation** (yage-docs content — no Go code)

## Level 3 Checklist

- [x] `mkdocs build --strict` passes
- [x] No broken internal links

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] Active Work table matches observed git/GH state
- [x] Next Steps updated with Phase H ordering

## Breaking Changes

None.