### PR TITLE
docs(state): PO sessions 6–8 — Phase H prereqs + ADR 0011 implemented + cross-repo PRs in review

### DIFF
--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -2,24 +2,60 @@
 
 ## Living Memory
 
-yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. Phase H (on-prem platform services via OpenTofu) is in late-stage implementation — ADRs 0009/0010/0011 accepted; orchestrator wiring for EnsureIssuingCA (#126/PR #163) and EnsureRepoSync (#144/PR #164) merged; only #125 (registry VM orchestrator wiring) remains. **Cross-repo gap**: yage-tofu currently has only the 8 identity modules (no `issuing-ca/` or `registry/` modules) — orchestrator wiring is dormant until those land in yage-tofu (tracked separately). ADR 0011 (pivot state migration) is substantially implemented; only #148 (extended HandOff + VerifyParity, plus a phase-order fix in bootstrap.go per ADR 0011 §7) remains.
+yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. **ADR 0011 (pivot state migration) is fully implemented** — yage PR #166 (`bb60c79`) merged today closes #148. Phase H (on-prem platform services via OpenTofu) orchestrator wiring is complete on the yage side (EnsureIssuingCA #163, EnsureRepoSync #164, EnsureManagementInstall #160, JobRunner k8s backend #162); only #125 (registry VM orchestrator wiring) remains, HELD pending architect review of the cross-repo modules. **Cross-repo gap is closing, not closed**: yage-tofu PR #6 (`registry/`, closes yage-tofu#5) and PR #7 (`issuing-ca/`, closes yage-tofu#4) are now open and need architect review (5 decisions + 2 contradictions flagged in PR bodies). yage-side wiring stays dormant (`ErrNotApplicable`-guarded) until they merge. ADR 0012 — yage-manifests template layout addendum to ADR 0008 — is open as yage-docs PR #11 and pins the `missingkey=error` policy + wrapper-struct contract that #136 needs.
 
 ## Freshness Policy
 
 This file must be updated whenever system state evolves (per CODING_STANDARDS.md "Atomic Persistence"). If information here conflicts with what you observe in the code or git history, trust what you observe now — then update this file to match reality.
 
-Last updated: **2026-05-01** — PO session 7 (post-dispatch): PRs #161 ✅ `d6e7d0a`, #163 ✅ `7b9d19b`, #164 ✅ `e7d116e` all merged; #126/#144/#152 closed; backend agents A/B/C at Halt for #148/#125/#136; cross-repo gap surfaced (yage-tofu missing `issuing-ca/` and `registry/` modules).
+Last updated: **2026-05-01** — PO session 8: PR #166 (`bb60c79`) merged — closes #148, fully implements ADR 0011, clears yage-backend (A) HALT. yage-tofu PR #6 (`registry/`, closes yage-tofu#5) and PR #7 (`issuing-ca/`, closes yage-tofu#4) opened for architect review. yage-docs PR #11 (ADR 0012) opened — closes #136 design pick #2. yage-backend (B) rotated from HELD #125 onto now-unblocked #136 and is **executing** on `feat/136-manifests-fetcher`. #125 remains HELD pending review of yage-tofu PRs #6/#7. #137–#141 remain gated on #136 landing.
 
 ## Version Baseline
 
 | Repo | Branch | Recent PRs | Status |
 |---|---|---|---|
-| yage | `main` | #164 (EnsureRepoSync, `e7d116e`), #163 (EnsureIssuingCA, `7b9d19b`), #161 (admin token TUI, `d6e7d0a`), #162 (JobRunner k8s backend), #160 (EnsureManagementInstall), #159 (profile bugs), #158 (Phase H TUI), #157 (double prompt fix), #156 (timeframe+ctrl+alt fix), #150, #149, #143, #132 | Active development; 3 backend agents at Halt for #148/#125/#136 |
-| yage-docs | `main` | PR #9 (remove codeql.yml), PR #8 (ADRs 0010+0011+CURRENT_STATE) | Up to date |
-| yage-tofu | `main` | PR #2 (kubernetes backend all 8 modules), PR #3 (license) | Up to date |
-| yage-manifests | `init` | PR #3 (license) | Scaffolded, awaiting templates |
+| yage | `main` | #166 (label-based yage-system handoff + extended VerifyParity, `bb60c79`), #164 (EnsureRepoSync, `e7d116e`), #163 (EnsureIssuingCA, `7b9d19b`), #161 (admin token TUI, `d6e7d0a`), #162 (JobRunner k8s backend), #160 (EnsureManagementInstall), #159, #158, #157, #156, #150, #149, #143, #132 | Active development; (A) HALT cleared by #166; (B) executing #136; #125 HELD |
+| yage-docs | `main` + open PR #11 (ADR 0012) | PR #9 (remove codeql.yml), PR #8 (ADRs 0010+0011+CURRENT_STATE) | PR #11 awaiting architect review |
+| yage-tofu | `main` + open PRs #6, #7 | PR #2 (kubernetes backend all 8 modules), PR #3 (license) | PRs #6 (registry) + #7 (issuing-ca) awaiting architect review |
+| yage-manifests | `init` | PR #3 (license) | Scaffolded, awaiting templates (#137–#141 gated on #136) |
 
 ## Recent Changes
+
+### 2026-05-01 — PO session 8: #148 merged; cross-repo PRs opened; ADR 0012 in review; (B) rotated onto #136
+
+**yage merged:**
+- **PR #166** (`bb60c79`, squash) — `feat(kindsync+pivot): label-based yage-system handoff + extended VerifyParity (#148)`. Closes #148. Fully implements ADR 0011. Clears yage-backend (A) HALT. ✅
+
+**Issues closed (auto on merge):** #148.
+
+**Cross-repo PRs opened (awaiting architect review):**
+
+- **yage-tofu PR #6** — `feat: add registry/ module for Phase H bootstrap registry (#5)` on `registry-module`. Closes yage-tofu#5. Five interpretive decisions flagged for architect:
+  1. **kubernetes backend** used despite ADR 0009 §1 wording `~/.yage/tofu/registry/terraform.tfstate` (local) — possible erratum to ADR 0009; reconcile against the kubernetes-backend convention established by yage-tofu PR #2 / yage #145. *(Note: architect agent is concurrently drafting `docs/adr-0009-erratum-kubernetes-backend` to address this.)*
+  2. `vm_flavor` split into discrete `registry_vm_cores` / `registry_vm_memory_mb` / `registry_vm_disk_gb` (defaults 2 / 4 GiB / 100 GiB) instead of single `YAGE_REGISTRY_VM_FLAVOR` knob.
+  3. TLS material exposed as PEM strings (`registry_tls_cert_pem`, `registry_tls_key_pem`, `registry_ca_bundle_pem`); defaults `""` so plan succeeds without certs.
+  4. Cloud-init bash bootstrap pulling Harbor 2.11.0 / Zot v2.1.0 on first boot; no baked image; image seeding remains an operator step per ADR 0009 §1.
+  5. `registry_template_id` is a required input — operator must supply a cloud-init enabled template ID.
+
+- **yage-tofu PR #7** — `feat: add issuing-ca/ module — online intermediate CA (#4)` on `feat/4-issuing-ca-module`. Closes yage-tofu#4. Two contradictions surfaced in the PR body:
+  1. **Output names not yet consumed by yage.** `EnsureIssuingCA` at `7b9d19b` generates the intermediate inline using Go `crypto/x509` and never calls `tofu output`. Module names mirror the Go-side material so a follow-up Go-side migration to `JobRunner.Output` becomes a no-op contract change.
+  2. **Root CA is an input, not generated.** yage-tofu#4 brief said "root + intermediate via `tls_self_signed_cert` / `tls_locally_signed_cert`" but yage code receives the root from operator config (`cfg.IssuingCARootCert` / `cfg.IssuingCARootKey`). Module follows Go-side semantics: offline-managed root is an input variable, not a TF resource — preserves the offline-root boundary per ADR 0009.
+
+**yage-docs PR opened (awaiting architect):**
+- **yage-docs PR #11** — `docs(adr): ADR 0012 — yage-manifests template layout and data contract` on `docs/adr-0008-addendum-template-layout`. Addendum to ADR 0008 pinning: on-disk layout (`cluster/`, `addons/<addon>/`, `csi/<driver>/`, `postsync/`), `missingkey=error` rendering policy, six wrapper-struct data contracts, full migration mapping table (helmvalues + wlargocd + postsync + caaph + cilium LBIPAMPool + 14 CSI drivers). Closes the open design pick #2 on #136 in the affirmative. Per-source-package grouping rejected (would split an add-on across two trees).
+
+**Unblocking moves this session:**
+
+- **#148 merged** (PR #166) clears yage-backend (A) HALT — agent rolls off.
+- **#136 unblocked** — its only deps were #135 (`d13e0eb`) and #144 (`e7d116e`), both merged in session 7. ADR 0012 (yage-docs PR #11) closes the last open design pick (`missingkey=error` confirmed). yage-backend (B) rotated from HELD #125 onto #136 and is now **executing** on `feat/136-manifests-fetcher`. The constructor-shape pick (zero-value `Fetcher` vs `NewFetcher()`) remains a small open decision but is not blocking.
+- **#125 unblocked by code dependencies** (#123 ✅, #124 ✅, #144 ✅, #148 ✅ — the bootstrap.go phase reorder by #148 removes the merge-conflict risk on `bootstrap.go`) but **HELD** pending architect review of yage-tofu PR #6 (registry module). The 3 questions raised in session 7 are partly answered: the yage-tofu module now exists in PR #6, but the architect must accept the 5 flagged decisions before yage-side wiring lands.
+- **#137–#141** (manifests migration chain) remain gated on #136 merging.
+
+**Architect lane (loaded):** review yage-tofu PR #6 (5 decisions), yage-tofu PR #7 (2 contradictions), yage-docs PR #11 (ADR 0012). All three have CI-clean, well-documented PR bodies; reviews are decision-gating, not detail-gating. Architect already drafting ADR 0009 erratum E1 (decision #1 on PR #6).
+
+**Next session moves:** (1) architect resolves 3 PR reviews; (2) Programmer merges yage-docs PR #11 once accepted; (3) Programmer merges yage-tofu PRs #6/#7 once accepted (this unblocks #125 Execute); (4) backend (B) lands #136 → unblocks #137–#141 chain.
+
+---
 
 ### 2026-05-01 — PO session 7: dispatch executed; 3 PRs merged; 3 backend halts
 
@@ -62,7 +98,7 @@ yage-tofu top-level has only `aws/`, `azure/`, `gcp/`, `ibmcloud/`, `linode/`, `
 - **PR #162** — `feat(opentofux): switch JobRunner to OpenTofu kubernetes backend; eliminate tofu-state PVCs`. Closes #145 (yage side). ✅
 - **PR #165** — `chore: remove codeql.yml`. CodeQL was not gating Merge Gate; removed to clean up check list. ✅
 
-**yage PRs open — CI green, awaiting merge:**
+**yage PRs open at session 6 close — CI green, awaiting merge:**
 - **PR #161** — `feat(xapiri): Proxmox admin token config in TUI; fix AdminToken kind Secret leak`. Closes #152. ⏳
 - **PR #163** — `feat(opentofux): EnsureIssuingCA — generate intermediate CA + wire cert-manager ClusterIssuer`. Closes #126. ⏳
 - **PR #164** — `feat(opentofux): implement EnsureRepoSync — yage-repos PVC + yage-repo-sync Job (ADR 0010, #144)`. Closes #144. ⏳
@@ -92,11 +128,6 @@ yage-tofu top-level has only `aws/`, `azure/`, `gcp/`, `ibmcloud/`, `linode/`, `
 - #151 (double prompt) — PR #157 ✅
 - #153 (profile bugs) — PR #159 ✅
 - #154 (timeframe keys) + #155 (ctrl+alt shortcuts) — PR #156 ✅
-
-**Issues pending closure (awaiting PR merge):**
-- #126 (EnsureIssuingCA) — PR #163 open, CI green ⏳
-- #144 (EnsureRepoSync) — PR #164 open, CI green ⏳
-- #152 (admin token TUI) — PR #161 open, CI green ⏳
 
 ---
 
@@ -130,11 +161,11 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 | Issue / PR | Branch | Agent | Description | Status |
 |---|---|---|---|---|
-| #148 | `feat/148-handoff-yage-system` | **yage-backend (A)** | extend `HandOffBootstrapSecretsToManagement` (labeled yage-system copy) + extend `VerifyParity` (ns + labeled Secrets + yage-repos PVC) + **reorder pivot phases per ADR 0011 §7** | **HALT** — p1; awaiting user OK to Execute |
-| #125 | `feat/125-registry-vm` | **yage-backend (B)** | provision bootstrap registry VM via OpenTofu; mirror `EnsureIssuingCA` shape; auto-wire `ImageRegistryMirror` | **HALT** — p2; 3 open questions for user (see session 7 entry) |
-| #136 | `feat/136-manifests-fetcher` | **yage-backend (C)** | `internal/platform/manifests` Fetcher package (MountRoot-based, no local clone); ADR 0008 step 2 | **HALT** — p2; 2 design picks for user (constructor shape, `missingkey=error`) |
-| yage-tofu#4 | TBD | **yage-backend** (cross-repo) | add `yage-tofu/issuing-ca/` OpenTofu module — companion to merged yage PR #163 | **Open** — p2 |
-| yage-tofu#5 | TBD | **yage-backend** (cross-repo) | add `yage-tofu/registry/` OpenTofu module — companion to in-flight yage #125 | **Open** — p2 |
+| yage-tofu PR #6 | `registry-module` (yage-tofu) | **yage-architect** review | `registry/` OpenTofu module — Phase H bootstrap registry; closes yage-tofu#5; 5 decisions flagged in PR body | **Awaiting architect review** — p2 |
+| yage-tofu PR #7 | `feat/4-issuing-ca-module` (yage-tofu) | **yage-architect** review | `issuing-ca/` OpenTofu module — online intermediate CA; closes yage-tofu#4; 2 contradictions surfaced in PR body | **Awaiting architect review** — p2 |
+| yage-docs PR #11 | `docs/adr-0008-addendum-template-layout` (yage-docs) | **yage-architect** review | ADR 0012 — yage-manifests template layout + data contract; addendum to ADR 0008; closes #136 design pick #2 | **Awaiting architect review** — p2 |
+| #136 | `feat/136-manifests-fetcher` (yage) | **yage-backend (B)** | `internal/platform/manifests` Fetcher package (MountRoot-based, no local clone); ADR 0008 step 2 | **In progress** — p2; constructor-shape pick still open (not blocking) |
+| #125 | `feat/125-registry-vm` (yage) | **yage-backend** (TBD) | provision bootstrap registry VM via OpenTofu; mirror `EnsureIssuingCA` shape; auto-wire `ImageRegistryMirror` | **HELD** — code unblocked, awaiting architect on yage-tofu PR #6 |
 | #137 | TBD | **yage-backend** | migrate `internal/capi/helmvalues/` to yage-manifests templates | **Blocked** on #136 |
 | #138 | TBD | **yage-backend** | migrate `internal/capi/wlargocd/` renderers to yage-manifests templates | **Blocked** on #136 |
 | #139 | TBD | **yage-backend** | migrate `internal/capi/postsync/` renderers to yage-manifests templates | **Blocked** on #136 |
@@ -146,13 +177,20 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 ---
 
+## HALT Records
+
+- **yage-backend (A) HALT — CLEARED** by PR #166 merge (`bb60c79`, 2026-05-01T11:12:11Z). Agent rolls off; #148 closed.
+- **yage-backend (B) HALT — CLEARED**. (B) rotated from HELD #125 onto #136 (now unblocked); executing on `feat/136-manifests-fetcher`.
+- **yage-backend (C) HALT — N/A** (rolled into the (B) #136 thread; only one agent on #136).
+
 ## Critical Path (in order)
 
-1. **User decides** on the 3 backend Halts — issue #148 (Execute OK?), issue #125 (3 questions), issue #136 (2 picks). Prefer batched OK to keep agents moving.
-2. **Backend agents Execute** their dispatched issues; PRs land normally via Workflow SOP.
-3. **PO opens cross-repo issues** in yage-tofu for `issuing-ca/` and `registry/` modules so the just-merged orchestrator wiring becomes operationally usable.
-4. **Phase H epic #120** closes once #125 lands AND yage-tofu modules ship. Track both arms.
-5. **Manifests migration chain** (#137–#142) unblocks once #136 ships.
+1. **Architect**: review yage-tofu PR #6 (5 decisions; ADR 0009 erratum E1 already in flight on `docs/adr-0009-erratum-kubernetes-backend`), yage-tofu PR #7 (2 contradictions), yage-docs PR #11 (ADR 0012). All three are decision-gating, not detail-gating.
+2. **Programmer**: merge yage-docs PR #11 once accepted (formalizes #136 design pick #2).
+3. **Programmer**: merge yage-tofu PRs #6 and #7 once accepted — unblocks #125 Execute.
+4. **yage-backend (B)**: land #136 (in progress) — unblocks the #137–#141 manifests migration chain.
+5. **yage-backend** (TBD): start #125 once yage-tofu PR #6 is merged and architect direction is clear.
+6. **Phase H epic #120** closes once #125 lands AND yage-tofu PRs #6/#7 ship.
 
 ---
 
@@ -174,6 +212,7 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 | 0006 | Capacity preflight architecture | Accepted |
 | 0007 | xapiri dashboard as default entry | Accepted |
 | 0008 | yage-manifests GitOps template repository | Accepted |
-| 0009 | On-prem platform services (Phase H): registry + issuing CA | Accepted |
+| 0009 | On-prem platform services (Phase H): registry + issuing CA | Accepted (erratum E1 in flight: kubernetes backend supersedes local tofu state) |
 | 0010 | In-cluster repository cache (zero workstation residue) | Accepted |
-| 0011 | Pivot: yage state migration to management cluster | Accepted |
+| 0011 | Pivot: yage state migration to management cluster | Accepted (fully implemented as of PR #166) |
+| 0012 | yage-manifests template layout and data contract (addendum to 0008) | **Proposed** (yage-docs PR #11) |

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -2,37 +2,54 @@
 
 ## Living Memory
 
-yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. Phase H (on-prem platform services via OpenTofu) implementation is underway — ADRs 0009/0010/0011 accepted, most Phase H prereqs merged. The pivot state migration ADR 0011 is fully implemented except #148 (extended HandOff + VerifyParity), which is now unblocked.
+yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. Phase H (on-prem platform services via OpenTofu) is underway — ADRs 0009/0010/0011 accepted, most prereqs merged; PRs #163 (EnsureIssuingCA / #126) and #164 (EnsureRepoSync / #144) are CI-green and pending merge, after which #148/#125/#136 are fully unblocked. ADR 0011 (pivot state migration) is substantially implemented; only #148 (extended HandOff + VerifyParity) remains.
 
 ## Freshness Policy
 
 This file must be updated whenever system state evolves (per CODING_STANDARDS.md "Atomic Persistence"). If information here conflicts with what you observe in the code or git history, trust what you observe now — then update this file to match reality.
 
-Last updated: **2026-05-01** — PO session 6: PRs #157–#165 merged; yage-tofu PRs #2–#3 merged; yage-manifests PR #3 merged; yage-docs PR #9 merged; all licenses added; CodeQL removed from yage + yage-docs; #148, #125, #136 now unblocked.
+Last updated: **2026-05-01** — PO session 7: corrected CURRENT_STATE — PRs #161, #163, #164 are OPEN (not merged); #157–#160, #162, #165 confirmed merged; dispatched #148, #136, #125 to yage-backend.
 
 ## Version Baseline
 
 | Repo | Branch | Recent PRs | Status |
 |---|---|---|---|
-| yage | `main` | #164 (EnsureRepoSync), #163 (EnsureIssuingCA), #162 (JobRunner k8s backend), #161 (admin token TUI), #160 (EnsureManagementInstall), #159 (profile bugs), #158 (Phase H TUI), #157 (double prompt fix), #156 (timeframe+ctrl+alt fix), #150 (EnsureYageSystemOnCluster), #149 (YAGE_MANIFESTS_REF), #143 (Fetcher PVC resolver), #132 (Phase H config fields) | Active development |
+| yage | `main` | #162 (JobRunner k8s backend), #160 (EnsureManagementInstall), #159 (profile bugs), #158 (Phase H TUI), #157 (double prompt fix), #156 (timeframe+ctrl+alt fix), #150 (EnsureYageSystemOnCluster), #149 (YAGE_MANIFESTS_REF), #143 (Fetcher PVC resolver), #132 (Phase H config fields) | Active development; PRs #161/#163/#164 open, CI green |
 | yage-docs | `main` | PR #9 (remove codeql.yml), PR #8 (ADRs 0010+0011+CURRENT_STATE) | Up to date |
 | yage-tofu | `main` | PR #2 (kubernetes backend all 8 modules), PR #3 (license) | Up to date |
 | yage-manifests | `init` | PR #3 (license) | Scaffolded, awaiting templates |
 
 ## Recent Changes
 
-### 2026-05-01 — PO session 6: Phase H prereqs complete; ADR 0011 fully implemented; licenses; CodeQL removed
+### 2026-05-01 — PO session 7: state correction; dispatch
+
+**Correction:** Session 6 entry below originally listed PRs #161, #163, #164 as merged. GitHub shows all three are still **OPEN with CI green**. Issues #126, #144, #152 remain open until those PRs merge. Session 6 entry corrected; this entry records the dispatch.
+
+**Dispatched (yage-backend, parallel after PR #164 merges):**
+- #148 (p1) — `HandOffBootstrapSecretsToManagement` label-pass + `VerifyParity` extension (closes ADR 0011)
+- #136 (p2) — `internal/platform/manifests` Fetcher package (unblocks #137–#142)
+- #125 (p2) — bootstrap registry VM via OpenTofu (closes Phase H epic #120 alongside PR #163)
+
+**Awaiting user merge:** PRs #161, #163, #164 (all CI green; rebase onto latest `main` immediately before merge per CodeQL-rescan rule).
+
+**Other agent lanes:** yage-frontend / yage-architect / yage-platform-engineer have no open issues; idle until follow-on work surfaces.
+
+---
+
+### 2026-05-01 — PO session 6: Phase H prereqs landed (partial); ADR 0011 substantially implemented; licenses; CodeQL removed
 
 **yage PRs merged:**
 - **PR #157** — `fix: skip pickBootstrapConfig before xapiri dashboard`. Closes #151. ✅
 - **PR #158** — `feat(xapiri+plan): surface Phase H registry and issuing CA fields`. Closes #127. ✅
 - **PR #159** — `fix(kindsync+xapiri): config profile system bug fixes`. Closes #153. ✅
 - **PR #160** — `feat(csi): Driver.EnsureManagementInstall — CSI on management cluster (ADR 0011, #147)`. Closes #147. ✅
-- **PR #161** — `feat(xapiri): Proxmox admin token config in TUI; fix AdminToken kind Secret leak`. Closes #152. ✅
 - **PR #162** — `feat(opentofux): switch JobRunner to OpenTofu kubernetes backend; eliminate tofu-state PVCs`. Closes #145 (yage side). ✅
-- **PR #163** — `feat(opentofux): EnsureIssuingCA — generate intermediate CA + wire cert-manager ClusterIssuer`. Closes #126. ✅
-- **PR #164** — `feat(opentofux): implement EnsureRepoSync — yage-repos PVC + yage-repo-sync Job (ADR 0010, #144)`. Closes #144. ✅
 - **PR #165** — `chore: remove codeql.yml`. CodeQL was not gating Merge Gate; removed to clean up check list. ✅
+
+**yage PRs open — CI green, awaiting merge:**
+- **PR #161** — `feat(xapiri): Proxmox admin token config in TUI; fix AdminToken kind Secret leak`. Closes #152. ⏳
+- **PR #163** — `feat(opentofux): EnsureIssuingCA — generate intermediate CA + wire cert-manager ClusterIssuer`. Closes #126. ⏳
+- **PR #164** — `feat(opentofux): implement EnsureRepoSync — yage-repos PVC + yage-repo-sync Job (ADR 0010, #144)`. Closes #144. ⏳
 
 **Also merged earlier in session (from session summary):**
 - **PR #156** — fix timeframe `[`/`]` keys on costs tab + remove ctrl+alt+Number tab shortcuts. Closes #154+#155. ✅
@@ -53,15 +70,17 @@ Last updated: **2026-05-01** — PO session 6: PRs #157–#165 merged; yage-tofu
 - yage-tofu and yage-manifests rulesets cleaned up: removed `code_quality`, `code_scanning`, `required_status_checks` (yage-tofu has no CI; yage-manifests has no CI). Both keep `pull_request` + `deletion` + `non_fast_forward`.
 
 **Issues closed this session:**
-- #126 (EnsureIssuingCA) — PR #163 ✅
 - #127 (Phase H TUI) — PR #158 ✅
-- #144 (EnsureRepoSync) — PR #164 ✅
 - #145 (kubernetes backend) — PR #162 + yage-tofu PR #2 ✅
 - #147 (EnsureManagementInstall) — PR #160 ✅
 - #151 (double prompt) — PR #157 ✅
-- #152 (admin token TUI) — PR #161 ✅
 - #153 (profile bugs) — PR #159 ✅
 - #154 (timeframe keys) + #155 (ctrl+alt shortcuts) — PR #156 ✅
+
+**Issues pending closure (awaiting PR merge):**
+- #126 (EnsureIssuingCA) — PR #163 open, CI green ⏳
+- #144 (EnsureRepoSync) — PR #164 open, CI green ⏳
+- #152 (admin token TUI) — PR #161 open, CI green ⏳
 
 ---
 
@@ -95,10 +114,12 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 | Issue / PR | Branch | Agent | Description | Status |
 |---|---|---|---|---|
-| #148 | TBD | **yage-backend** | Extend `HandOffBootstrapSecretsToManagement` (label-based yage-system copy) + extend `VerifyParity` (yage-system ns + labeled Secrets + yage-repos PVC) | **Unblocked** — p1, all blockers merged (#144 ✅, #145 ✅, #146 ✅, #147 ✅) |
-| #125 | TBD | **yage-backend** | orchestrator: provision bootstrap registry VM via OpenTofu | **Unblocked** — p2 (was blocked on #123 ✅, #124 ✅, #144 ✅) |
-| #136 | TBD | **yage-backend** | `internal/platform/manifests` Fetcher package (MountRoot-based, no local clone) | **Unblocked** — p2 (was blocked on #135 ✅, #144 ✅) |
-| #134 | TBD | **yage-backend** / **ops** | scaffold `lpasquali/yage-manifests` repo structure | **Unblocked** — p2 |
+| PR #161 | `worktree-agent-a2aa9a093ec134e40` | **user / yage-backend** | merge xapiri admin token TUI; closes #152 | **CI green** — awaiting merge |
+| PR #163 | `feat/126-issuing-ca` | **user / yage-backend** | merge EnsureIssuingCA; closes #126; advances epic #120 | **CI green** — awaiting merge |
+| PR #164 | `worktree-agent-af60c9cba9f0fffa6` | **user / yage-backend** | merge EnsureRepoSync; closes #144; unblocks #148/#125/#136 | **CI green** — awaiting merge |
+| #148 | TBD | **yage-backend** | Extend `HandOffBootstrapSecretsToManagement` (label-based yage-system copy) + extend `VerifyParity` (yage-system ns + labeled Secrets + yage-repos PVC) | **Dispatched** — p1; starts after PR #164 merges (#144 ✅ on merge, #145 ✅, #146 ✅, #147 ✅) |
+| #136 | TBD | **yage-backend** | `internal/platform/manifests` Fetcher package (MountRoot-based, no local clone) | **Dispatched** — p2; starts after PR #164 merges; prerequisite for #137–#142 |
+| #125 | TBD | **yage-backend** | orchestrator: provision bootstrap registry VM via OpenTofu | **Dispatched** — p2; starts after PR #164 merges (was blocked on #123 ✅, #124 ✅, #144) |
 | #137 | TBD | **yage-backend** | migrate `internal/capi/helmvalues/` to yage-manifests templates | **Blocked** on #136 |
 | #138 | TBD | **yage-backend** | migrate `internal/capi/wlargocd/` renderers to yage-manifests templates | **Blocked** on #136 |
 | #139 | TBD | **yage-backend** | migrate `internal/capi/postsync/` renderers to yage-manifests templates | **Blocked** on #136 |
@@ -106,16 +127,22 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 | #141 | TBD | **yage-backend** | CSI `RenderValues` → `Render` + port all 14 drivers to yage-manifests (atomic) | **Blocked** on #136 |
 | #142 | TBD | **yage-backend** | retire `helmvalues/`, `wlargocd/`, `postsync/` packages | **Blocked** on #137–#141 |
 | #119 | TBD | **yage-backend** | D4: CAPD smoke E2E test for bootstrap pipeline | **Backlog** — p3 |
-| #94–#101 | TBD | **yage-backend** | PlanDescriber for 8 providers (Linode, CAPD, OpenStack, vSphere, Azure, IBM, GCP, DO) | **Backlog** — p3 (epic #78) |
+| #94–#101 | TBD | **yage-backend** | PlanDescriber for 8 providers (Linode, CAPD, OpenStack, vSphere, Azure, IBM, GCP, DO) | **Backlog** — p3 (epic #78); parallelizable across multiple backend instances |
 
 ---
 
-## Critical Path (unblocked work agents can start now)
+## Critical Path (in order)
 
-1. **yage-backend: start #148** (`HandOff` label pass + `VerifyParity` extension) — p1, all prereqs done
-2. **yage-backend: start #125** (registry VM via OpenTofu) — p2, unblocked
-3. **yage-backend: start #136** (`manifests.Fetcher` package) — p2, unblocked; prerequisite for #137–#142
-4. **yage-backend: start #134** (scaffold yage-manifests repo) — p2, independent
+1. **Merge PRs #161, #163, #164** — all CI green; closes #126/#144/#152 and unblocks the next wave
+2. **yage-backend: start #148** (`HandOff` label pass + `VerifyParity` extension) — p1, after PR #164 merges
+3. **yage-backend: start #136** (`manifests.Fetcher` package) — p2; prerequisite for #137–#142
+4. **yage-backend: start #125** (registry VM via OpenTofu) — p2; closes Phase H epic #120 alongside PR #163
+
+## Other agent lanes (no open issues)
+
+- **yage-frontend** — idle; reopen if Phase H/H+ surfaces TUI gaps after PRs land
+- **yage-architect** — idle; next ADR likely Phase I scope after yage-manifests migration completes
+- **yage-platform-engineer** — idle; reactivate for review when CAPI manifest patches return (e.g. registry mirror wiring in #125)
 
 ---
 

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -2,7 +2,7 @@
 
 ## Living Memory
 
-yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. **ADR 0011 (pivot state migration) is fully implemented** — yage PR #166 (`bb60c79`) merged today closes #148. Phase H (on-prem platform services via OpenTofu) orchestrator wiring is complete on the yage side (EnsureIssuingCA #163, EnsureRepoSync #164, EnsureManagementInstall #160, JobRunner k8s backend #162); only #125 (registry VM orchestrator wiring) remains, HELD pending architect review of the cross-repo modules. **Cross-repo gap is closing, not closed**: yage-tofu PR #6 (`registry/`, closes yage-tofu#5) and PR #7 (`issuing-ca/`, closes yage-tofu#4) are now open and need architect review (5 decisions + 2 contradictions flagged in PR bodies). yage-side wiring stays dormant (`ErrNotApplicable`-guarded) until they merge. ADR 0012 — yage-manifests template layout addendum to ADR 0008 — is open as yage-docs PR #11 and pins the `missingkey=error` policy + wrapper-struct contract that #136 needs.
+yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. **ADR 0011 (pivot state migration) is fully implemented** — yage PR #166 (`bb60c79`) merged today closes #148. Phase H (on-prem platform services via OpenTofu) orchestrator wiring is complete on the yage side (EnsureIssuingCA #163, EnsureRepoSync #164, EnsureManagementInstall #160, JobRunner k8s backend #162); only #125 (registry VM orchestrator wiring) remains, HELD pending architect review of the cross-repo modules. **Cross-repo gap is closing, not closed**: yage-tofu PR #6 (`registry/`, closes yage-tofu#5) and PR #7 (`issuing-ca/`, closes yage-tofu#4) are now open and need architect review (5 decisions + 2 contradictions flagged in PR bodies). yage-side wiring stays dormant (`ErrNotApplicable`-guarded) until they merge. ADR 0012 — yage-manifests template layout addendum to ADR 0008 — **merged** as yage-docs PR #11 (`1cdf251`); pins the `missingkey=error` policy + wrapper-struct contract that #136 needs. ADR 0009 erratum E1 (kubernetes backend supersedes local tofu state) **merged** as yage-docs PR #12 (`20cb4b9`). Phase H bootstrap runbook **merged** as yage-docs PR #13 (`c1930af`).
 
 ## Freshness Policy
 
@@ -15,7 +15,7 @@ Last updated: **2026-05-01** — PO session 8: PR #166 (`bb60c79`) merged — cl
 | Repo | Branch | Recent PRs | Status |
 |---|---|---|---|
 | yage | `main` | #166 (label-based yage-system handoff + extended VerifyParity, `bb60c79`), #164 (EnsureRepoSync, `e7d116e`), #163 (EnsureIssuingCA, `7b9d19b`), #161 (admin token TUI, `d6e7d0a`), #162 (JobRunner k8s backend), #160 (EnsureManagementInstall), #159, #158, #157, #156, #150, #149, #143, #132 | Active development; (A) HALT cleared by #166; (B) executing #136; #125 HELD |
-| yage-docs | `main` + open PR #11 (ADR 0012) | PR #9 (remove codeql.yml), PR #8 (ADRs 0010+0011+CURRENT_STATE) | PR #11 awaiting architect review |
+| yage-docs | `main` | PR #13 (Phase H runbook, `c1930af`), PR #12 (ADR 0009 erratum E1, `20cb4b9`), PR #11 (ADR 0012 template layout, `1cdf251`), PR #9 (remove codeql.yml), PR #8 (ADRs 0010+0011+CURRENT_STATE) | PR #11/#12/#13 merged |
 | yage-tofu | `main` + open PRs #6, #7 | PR #2 (kubernetes backend all 8 modules), PR #3 (license) | PRs #6 (registry) + #7 (issuing-ca) awaiting architect review |
 | yage-manifests | `init` | PR #3 (license) | Scaffolded, awaiting templates (#137–#141 gated on #136) |
 
@@ -31,7 +31,7 @@ Last updated: **2026-05-01** — PO session 8: PR #166 (`bb60c79`) merged — cl
 **Cross-repo PRs opened (awaiting architect review):**
 
 - **yage-tofu PR #6** — `feat: add registry/ module for Phase H bootstrap registry (#5)` on `registry-module`. Closes yage-tofu#5. Five interpretive decisions flagged for architect:
-  1. **kubernetes backend** used despite ADR 0009 §1 wording `~/.yage/tofu/registry/terraform.tfstate` (local) — possible erratum to ADR 0009; reconcile against the kubernetes-backend convention established by yage-tofu PR #2 / yage #145. *(Note: architect agent is concurrently drafting `docs/adr-0009-erratum-kubernetes-backend` to address this.)*
+  1. **kubernetes backend** used despite ADR 0009 §1 wording `~/.yage/tofu/registry/terraform.tfstate` (local) — resolved by ADR 0009 erratum E1 (yage-docs PR #12, `20cb4b9`).
   2. `vm_flavor` split into discrete `registry_vm_cores` / `registry_vm_memory_mb` / `registry_vm_disk_gb` (defaults 2 / 4 GiB / 100 GiB) instead of single `YAGE_REGISTRY_VM_FLAVOR` knob.
   3. TLS material exposed as PEM strings (`registry_tls_cert_pem`, `registry_tls_key_pem`, `registry_ca_bundle_pem`); defaults `""` so plan succeeds without certs.
   4. Cloud-init bash bootstrap pulling Harbor 2.11.0 / Zot v2.1.0 on first boot; no baked image; image seeding remains an operator step per ADR 0009 §1.
@@ -41,8 +41,10 @@ Last updated: **2026-05-01** — PO session 8: PR #166 (`bb60c79`) merged — cl
   1. **Output names not yet consumed by yage.** `EnsureIssuingCA` at `7b9d19b` generates the intermediate inline using Go `crypto/x509` and never calls `tofu output`. Module names mirror the Go-side material so a follow-up Go-side migration to `JobRunner.Output` becomes a no-op contract change.
   2. **Root CA is an input, not generated.** yage-tofu#4 brief said "root + intermediate via `tls_self_signed_cert` / `tls_locally_signed_cert`" but yage code receives the root from operator config (`cfg.IssuingCARootCert` / `cfg.IssuingCARootKey`). Module follows Go-side semantics: offline-managed root is an input variable, not a TF resource — preserves the offline-root boundary per ADR 0009.
 
-**yage-docs PR opened (awaiting architect):**
-- **yage-docs PR #11** — `docs(adr): ADR 0012 — yage-manifests template layout and data contract` on `docs/adr-0008-addendum-template-layout`. Addendum to ADR 0008 pinning: on-disk layout (`cluster/`, `addons/<addon>/`, `csi/<driver>/`, `postsync/`), `missingkey=error` rendering policy, six wrapper-struct data contracts, full migration mapping table (helmvalues + wlargocd + postsync + caaph + cilium LBIPAMPool + 14 CSI drivers). Closes the open design pick #2 on #136 in the affirmative. Per-source-package grouping rejected (would split an add-on across two trees).
+**yage-docs PRs merged (post-session-8):**
+- **yage-docs PR #11** (`1cdf251`) — `docs(adr): ADR 0012 — yage-manifests template layout and data contract`. Addendum to ADR 0008 pinning: on-disk layout (`cluster/`, `addons/<addon>/`, `csi/<driver>/`, `postsync/`), `missingkey=error` rendering policy, six wrapper-struct data contracts, full migration mapping table (helmvalues + wlargocd + postsync + caaph + cilium LBIPAMPool + 14 CSI drivers). Closes the open design pick #2 on #136 in the affirmative.
+- **yage-docs PR #12** (`20cb4b9`) — `docs(adr-0009): erratum E1 — kubernetes backend supersedes local tofu state`. Resolves decision #1 on yage-tofu PR #6.
+- **yage-docs PR #13** (`c1930af`) — `docs(operations): add Phase H bootstrap runbook (registry + issuing CA)`.
 
 **Unblocking moves this session:**
 
@@ -51,9 +53,9 @@ Last updated: **2026-05-01** — PO session 8: PR #166 (`bb60c79`) merged — cl
 - **#125 unblocked by code dependencies** (#123 ✅, #124 ✅, #144 ✅, #148 ✅ — the bootstrap.go phase reorder by #148 removes the merge-conflict risk on `bootstrap.go`) but **HELD** pending architect review of yage-tofu PR #6 (registry module). The 3 questions raised in session 7 are partly answered: the yage-tofu module now exists in PR #6, but the architect must accept the 5 flagged decisions before yage-side wiring lands.
 - **#137–#141** (manifests migration chain) remain gated on #136 merging.
 
-**Architect lane (loaded):** review yage-tofu PR #6 (5 decisions), yage-tofu PR #7 (2 contradictions), yage-docs PR #11 (ADR 0012). All three have CI-clean, well-documented PR bodies; reviews are decision-gating, not detail-gating. Architect already drafting ADR 0009 erratum E1 (decision #1 on PR #6).
+**Architect lane (loaded):** review yage-tofu PR #6 (5 decisions), yage-tofu PR #7 (2 contradictions). yage-docs PR #11 (ADR 0012), PR #12 (ADR 0009 erratum E1), PR #13 (Phase H runbook) all **merged** post-session.
 
-**Next session moves:** (1) architect resolves 3 PR reviews; (2) Programmer merges yage-docs PR #11 once accepted; (3) Programmer merges yage-tofu PRs #6/#7 once accepted (this unblocks #125 Execute); (4) backend (B) lands #136 → unblocks #137–#141 chain.
+**Next session moves:** (1) architect resolves yage-tofu PR #6/#7 reviews; (2) Programmer merges yage-tofu PRs #6/#7 once accepted (this unblocks #125 Execute); (3) backend (B) lands #136 → unblocks #137–#141 chain.
 
 ---
 
@@ -163,7 +165,9 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 |---|---|---|---|---|
 | yage-tofu PR #6 | `registry-module` (yage-tofu) | **yage-architect** review | `registry/` OpenTofu module — Phase H bootstrap registry; closes yage-tofu#5; 5 decisions flagged in PR body | **Awaiting architect review** — p2 |
 | yage-tofu PR #7 | `feat/4-issuing-ca-module` (yage-tofu) | **yage-architect** review | `issuing-ca/` OpenTofu module — online intermediate CA; closes yage-tofu#4; 2 contradictions surfaced in PR body | **Awaiting architect review** — p2 |
-| yage-docs PR #11 | `docs/adr-0008-addendum-template-layout` (yage-docs) | **yage-architect** review | ADR 0012 — yage-manifests template layout + data contract; addendum to ADR 0008; closes #136 design pick #2 | **Awaiting architect review** — p2 |
+| yage-docs PR #11 | `docs/adr-0008-addendum-template-layout` (yage-docs) | merged | ADR 0012 — yage-manifests template layout + data contract; addendum to ADR 0008; closes #136 design pick #2 | **Merged** (`1cdf251`) |
+| yage-docs PR #12 | `docs/adr-0009-erratum-kubernetes-backend` (yage-docs) | merged | ADR 0009 erratum E1 — kubernetes backend supersedes local tofu state | **Merged** (`20cb4b9`) |
+| yage-docs PR #13 | `docs/operations-phase-h-runbook` (yage-docs) | merged | Phase H bootstrap runbook (registry + issuing CA) | **Merged** (`c1930af`) |
 | #136 | `feat/136-manifests-fetcher` (yage) | **yage-backend (B)** | `internal/platform/manifests` Fetcher package (MountRoot-based, no local clone); ADR 0008 step 2 | **In progress** — p2; constructor-shape pick still open (not blocking) |
 | #125 | `feat/125-registry-vm` (yage) | **yage-backend** (TBD) | provision bootstrap registry VM via OpenTofu; mirror `EnsureIssuingCA` shape; auto-wire `ImageRegistryMirror` | **HELD** — code unblocked, awaiting architect on yage-tofu PR #6 |
 | #137 | TBD | **yage-backend** | migrate `internal/capi/helmvalues/` to yage-manifests templates | **Blocked** on #136 |
@@ -185,12 +189,11 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 ## Critical Path (in order)
 
-1. **Architect**: review yage-tofu PR #6 (5 decisions; ADR 0009 erratum E1 already in flight on `docs/adr-0009-erratum-kubernetes-backend`), yage-tofu PR #7 (2 contradictions), yage-docs PR #11 (ADR 0012). All three are decision-gating, not detail-gating.
-2. **Programmer**: merge yage-docs PR #11 once accepted (formalizes #136 design pick #2).
-3. **Programmer**: merge yage-tofu PRs #6 and #7 once accepted — unblocks #125 Execute.
-4. **yage-backend (B)**: land #136 (in progress) — unblocks the #137–#141 manifests migration chain.
-5. **yage-backend** (TBD): start #125 once yage-tofu PR #6 is merged and architect direction is clear.
-6. **Phase H epic #120** closes once #125 lands AND yage-tofu PRs #6/#7 ship.
+1. **Architect**: review yage-tofu PR #6 (5 decisions — decision #1 already settled by ADR 0009 erratum E1 merged in yage-docs PR #12 `20cb4b9`), yage-tofu PR #7 (2 contradictions). yage-docs PR #11 (ADR 0012, `1cdf251`), PR #12 (`20cb4b9`), PR #13 (`c1930af`) all merged.
+2. **Programmer**: merge yage-tofu PRs #6 and #7 once accepted — unblocks #125 Execute.
+3. **yage-backend (B)**: land #136 (in progress) — unblocks the #137–#141 manifests migration chain.
+4. **yage-backend** (TBD): start #125 once yage-tofu PR #6 is merged and architect direction is clear.
+5. **Phase H epic #120** closes once #125 lands AND yage-tofu PRs #6/#7 ship.
 
 ---
 
@@ -212,7 +215,7 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 | 0006 | Capacity preflight architecture | Accepted |
 | 0007 | xapiri dashboard as default entry | Accepted |
 | 0008 | yage-manifests GitOps template repository | Accepted |
-| 0009 | On-prem platform services (Phase H): registry + issuing CA | Accepted (erratum E1 in flight: kubernetes backend supersedes local tofu state) |
+| 0009 | On-prem platform services (Phase H): registry + issuing CA | Accepted (erratum E1 merged in yage-docs PR #12 `20cb4b9`: kubernetes backend supersedes local tofu state) |
 | 0010 | In-cluster repository cache (zero workstation residue) | Accepted |
 | 0011 | Pivot: yage state migration to management cluster | Accepted (fully implemented as of PR #166) |
-| 0012 | yage-manifests template layout and data contract (addendum to 0008) | **Proposed** (yage-docs PR #11) |
+| 0012 | yage-manifests template layout and data contract (addendum to 0008) | Accepted (yage-docs PR #11 merged `1cdf251`) |

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -2,37 +2,53 @@
 
 ## Living Memory
 
-yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. Phase H (on-prem platform services via OpenTofu) is underway — ADRs 0009/0010/0011 accepted, most prereqs merged; PRs #163 (EnsureIssuingCA / #126) and #164 (EnsureRepoSync / #144) are CI-green and pending merge, after which #148/#125/#136 are fully unblocked. ADR 0011 (pivot state migration) is substantially implemented; only #148 (extended HandOff + VerifyParity) remains.
+yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. Phase H (on-prem platform services via OpenTofu) is in late-stage implementation — ADRs 0009/0010/0011 accepted; orchestrator wiring for EnsureIssuingCA (#126/PR #163) and EnsureRepoSync (#144/PR #164) merged; only #125 (registry VM orchestrator wiring) remains. **Cross-repo gap**: yage-tofu currently has only the 8 identity modules (no `issuing-ca/` or `registry/` modules) — orchestrator wiring is dormant until those land in yage-tofu (tracked separately). ADR 0011 (pivot state migration) is substantially implemented; only #148 (extended HandOff + VerifyParity, plus a phase-order fix in bootstrap.go per ADR 0011 §7) remains.
 
 ## Freshness Policy
 
 This file must be updated whenever system state evolves (per CODING_STANDARDS.md "Atomic Persistence"). If information here conflicts with what you observe in the code or git history, trust what you observe now — then update this file to match reality.
 
-Last updated: **2026-05-01** — PO session 7: corrected CURRENT_STATE — PRs #161, #163, #164 are OPEN (not merged); #157–#160, #162, #165 confirmed merged; dispatched #148, #136, #125 to yage-backend.
+Last updated: **2026-05-01** — PO session 7 (post-dispatch): PRs #161 ✅ `d6e7d0a`, #163 ✅ `7b9d19b`, #164 ✅ `e7d116e` all merged; #126/#144/#152 closed; backend agents A/B/C at Halt for #148/#125/#136; cross-repo gap surfaced (yage-tofu missing `issuing-ca/` and `registry/` modules).
 
 ## Version Baseline
 
 | Repo | Branch | Recent PRs | Status |
 |---|---|---|---|
-| yage | `main` | #162 (JobRunner k8s backend), #160 (EnsureManagementInstall), #159 (profile bugs), #158 (Phase H TUI), #157 (double prompt fix), #156 (timeframe+ctrl+alt fix), #150 (EnsureYageSystemOnCluster), #149 (YAGE_MANIFESTS_REF), #143 (Fetcher PVC resolver), #132 (Phase H config fields) | Active development; PRs #161/#163/#164 open, CI green |
+| yage | `main` | #164 (EnsureRepoSync, `e7d116e`), #163 (EnsureIssuingCA, `7b9d19b`), #161 (admin token TUI, `d6e7d0a`), #162 (JobRunner k8s backend), #160 (EnsureManagementInstall), #159 (profile bugs), #158 (Phase H TUI), #157 (double prompt fix), #156 (timeframe+ctrl+alt fix), #150, #149, #143, #132 | Active development; 3 backend agents at Halt for #148/#125/#136 |
 | yage-docs | `main` | PR #9 (remove codeql.yml), PR #8 (ADRs 0010+0011+CURRENT_STATE) | Up to date |
 | yage-tofu | `main` | PR #2 (kubernetes backend all 8 modules), PR #3 (license) | Up to date |
 | yage-manifests | `init` | PR #3 (license) | Scaffolded, awaiting templates |
 
 ## Recent Changes
 
-### 2026-05-01 — PO session 7: state correction; dispatch
+### 2026-05-01 — PO session 7: dispatch executed; 3 PRs merged; 3 backend halts
 
-**Correction:** Session 6 entry below originally listed PRs #161, #163, #164 as merged. GitHub shows all three are still **OPEN with CI green**. Issues #126, #144, #152 remain open until those PRs merge. Session 6 entry corrected; this entry records the dispatch.
+**Correction (session start):** Session 6 entry below originally listed PRs #161, #163, #164 as merged. They were OPEN at session 7 start. This entry records the actual merge events.
 
-**Per-agent dispatch (each agent merges its assigned PR, then starts the linked issue):**
-- **yage-frontend** — merge PR #161 (closes #152, xapiri admin token TUI). Idle after.
-- **yage-backend (A)** — merge PR #164 (closes #144), then issue #148 (p1) `HandOff` label-pass + `VerifyParity` extension.
-- **yage-backend (B)** — merge PR #163 (closes #126), then issue #125 (p2) bootstrap registry VM via OpenTofu.
-- **yage-backend (C)** — issue #136 (p2) `manifests.Fetcher` package; gate: confirm PR #164 is on `main` before Execute.
-- **yage-architect / yage-platform-engineer** — standby; reactivate for #125 PR manifest review and Phase I ADR scope.
+**yage PRs merged this session:**
+- **PR #161** (`d6e7d0a`, squash) — `feat(xapiri): Proxmox admin token config in TUI; fix AdminToken kind Secret leak`. Closes #152. Merged by yage-frontend agent.
+- **PR #163** (`7b9d19b`, squash) — `feat(opentofux): EnsureIssuingCA — generate intermediate CA + wire cert-manager ClusterIssuer`. Closes #126. Merged by yage-backend (B); needed two rebases (parallel #164 merge raced).
+- **PR #164** (`e7d116e`, squash) — `feat(opentofux): implement EnsureRepoSync — yage-repos PVC + yage-repo-sync Job`. Closes #144. Merged by yage-backend (A).
 
-**Merge protocol** (every agent): rebase onto latest `main` immediately before merging to avoid a second CodeQL scan; use `gh pr merge <N> --squash`.
+**Issues closed this session (auto on merge):** #126, #144, #152.
+
+**Backend agents at Halt — awaiting user OK to Execute:**
+
+- **yage-backend (A)** on `feat/148-handoff-yage-system` — issue #148 plan: 3 changes (not 2). (1) `kindsync/handoff.go`: new `HandoffResult{NamedCopied, LabelCopied, FirstErr}` + `copyYageSystemSecrets` helper that SSA-applies labeled (`app.kubernetes.io/managed-by=yage`) Secrets in the `yage-system` namespace. (2) `pivot/pivot.go`: 3 verification helpers (ns-present, labeled-Secrets-present, yage-repos PVC bound) inside the existing poll loop. (3) **`bootstrap.go` phase reorder** — current order runs `VerifyParity` *before* `EnsureYageSystemOnCluster` and `EnsureRepoSync`, so the new checks would always fail; reorder per ADR 0011 §7 to: `MoveCAPIState → HandOff → EnsureYageSystemOnCluster → EnsureManagementInstall → EnsureRepoSync → VerifyParity → rebind`. Tests for both packages.
+
+- **yage-backend (B)** on `feat/125-registry-vm` — issue #125 plan: new `internal/platform/opentofux/registry.go` exposing `EnsureRegistry(ctx, cli, cfg) error` (mirrors `EnsureIssuingCA` shape: `ErrNotApplicable` when `RegistryNode==""`; preserves operator-set `ImageRegistryMirror`); wire into `bootstrap.go` post-`EnsureRepoSync` + `EnsureIdentity`, before workload manifest apply; `purge.go` integration to destroy registry before kind teardown; unit tests for the no-op/preserve paths. **Three open questions for user**:
+  1. `JobRunner.Output` is a known TODO referencing #125 explicitly; bundle its implementation (parse terminated-pod logs for `tofu output -json`) into this PR, or split?
+  2. `yage-tofu/registry/` module **does not exist on `lpasquali/yage-tofu` main** — only the 8 identity modules. Ship orchestrator wiring + no-op tests now (runtime path dormant unless `RegistryNode` set), and open follow-up issue for the OpenTofu module? Or hold #125 until module lands?
+  3. OK to add `NewJobRunnerWithClient(cfg, *k8sclient.Client)` constructor to mirror EnsureRepoSync wiring?
+
+- **yage-backend (C)** on `feat/136-manifests-fetcher` — issue #136 plan: new `internal/platform/manifests/fetcher.go` with zero-value `Fetcher{MountRoot}` (default `/repos`), `Render(templatePath, data any) (string, error)`, path = `<root>/yage-manifests/<templatePath>`, `text/template` with `Option("missingkey=error")`. Plus `_test.go` and a testdata fixture. **Two design picks for user**:
+  1. Zero-value `Fetcher` (mirrors opentofux pattern, agent recommends) **vs** `NewFetcher()` constructor (issue text suggests).
+  2. Confirm `Option("missingkey=error")` so missing config fields fail loud instead of silently rendering `<no value>`.
+
+**Cross-repo gap discovered + tracked:**
+yage-tofu top-level has only `aws/`, `azure/`, `gcp/`, `ibmcloud/`, `linode/`, `oci/`, `openstack/`, `proxmox/` (the 8 identity modules). The `issuing-ca/` and `registry/` modules — referenced by the just-merged PR #163 (EnsureIssuingCA) and the in-flight #125 (EnsureRegistry) respectively — do not exist. The yage-side orchestrator wiring is dormant (guarded by `ErrNotApplicable` when config fields are unset) so this is not a runtime regression, but the operator-facing feature is non-functional until the modules ship. **Tracking issues opened**: [yage-tofu#4 (issuing-ca/)](https://github.com/lpasquali/yage-tofu/issues/4) and [yage-tofu#5 (registry/)](https://github.com/lpasquali/yage-tofu/issues/5).
+
+**Architect / platform-engineer:** standby this session; no Execute work dispatched.
 
 ---
 
@@ -114,12 +130,11 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 | Issue / PR | Branch | Agent | Description | Status |
 |---|---|---|---|---|
-| PR #161 | `worktree-agent-a2aa9a093ec134e40` | **yage-frontend** | rebase onto `main`, force-push, then `gh pr merge 161 --squash` — closes #152 (xapiri admin token TUI) | **CI green** — assigned for merge |
-| PR #163 | `feat/126-issuing-ca` | **yage-backend (B)** | rebase onto `main`, force-push, then `gh pr merge 163 --squash` — closes #126 (EnsureIssuingCA); advances epic #120 | **CI green** — assigned for merge |
-| PR #164 | `worktree-agent-af60c9cba9f0fffa6` | **yage-backend (A)** | rebase onto `main`, force-push, then `gh pr merge 164 --squash` — closes #144 (EnsureRepoSync); unblocks #148/#136/#125 | **CI green** — assigned for merge |
-| #148 | new branch | **yage-backend (A)** | after merging PR #164, start: extend `HandOffBootstrapSecretsToManagement` (label-based yage-system copy) + extend `VerifyParity` (yage-system ns + labeled Secrets + yage-repos PVC) | **Dispatched** — p1 |
-| #125 | new branch | **yage-backend (B)** | after merging PR #163 and confirming PR #164 merged, start: provision bootstrap registry VM via OpenTofu and auto-wire `ImageRegistryMirror` | **Dispatched** — p2 |
-| #136 | new branch | **yage-backend (C)** | after PR #164 merge confirmed, start: `internal/platform/manifests` Fetcher package (MountRoot-based, no local clone); ADR 0008 step 2 | **Dispatched** — p2; prerequisite for #137–#142 |
+| #148 | `feat/148-handoff-yage-system` | **yage-backend (A)** | extend `HandOffBootstrapSecretsToManagement` (labeled yage-system copy) + extend `VerifyParity` (ns + labeled Secrets + yage-repos PVC) + **reorder pivot phases per ADR 0011 §7** | **HALT** — p1; awaiting user OK to Execute |
+| #125 | `feat/125-registry-vm` | **yage-backend (B)** | provision bootstrap registry VM via OpenTofu; mirror `EnsureIssuingCA` shape; auto-wire `ImageRegistryMirror` | **HALT** — p2; 3 open questions for user (see session 7 entry) |
+| #136 | `feat/136-manifests-fetcher` | **yage-backend (C)** | `internal/platform/manifests` Fetcher package (MountRoot-based, no local clone); ADR 0008 step 2 | **HALT** — p2; 2 design picks for user (constructor shape, `missingkey=error`) |
+| yage-tofu#4 | TBD | **yage-backend** (cross-repo) | add `yage-tofu/issuing-ca/` OpenTofu module — companion to merged yage PR #163 | **Open** — p2 |
+| yage-tofu#5 | TBD | **yage-backend** (cross-repo) | add `yage-tofu/registry/` OpenTofu module — companion to in-flight yage #125 | **Open** — p2 |
 | #137 | TBD | **yage-backend** | migrate `internal/capi/helmvalues/` to yage-manifests templates | **Blocked** on #136 |
 | #138 | TBD | **yage-backend** | migrate `internal/capi/wlargocd/` renderers to yage-manifests templates | **Blocked** on #136 |
 | #139 | TBD | **yage-backend** | migrate `internal/capi/postsync/` renderers to yage-manifests templates | **Blocked** on #136 |
@@ -131,22 +146,13 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 ---
 
-## Per-agent dispatch (session 7)
+## Critical Path (in order)
 
-**Each agent: rebase the assigned PR branch onto latest `main`, force-push, then `gh pr merge --squash`. Wait for CI confirmation.** The rebase-immediately-before-merge step is mandatory — see CODING_STANDARDS / SOP step 8 to avoid the second CodeQL scan.
-
-| Agent | Merge | Then start |
-|---|---|---|
-| **yage-frontend** | PR #161 → closes #152 | (idle) |
-| **yage-backend (A)** | PR #164 → closes #144 | issue #148 (p1) — `HandOff` + `VerifyParity` |
-| **yage-backend (B)** | PR #163 → closes #126 | issue #125 (p2) — registry VM via OpenTofu |
-| **yage-backend (C)** | (none) | issue #136 (p2) — `manifests.Fetcher` package; **gate**: confirm PR #164 merged on `main` before SOP step 5 (Execute) |
-| **yage-architect** | (none) | review ADR scope for Phase I (post yage-manifests migration); standby — no Execute work this session |
-| **yage-platform-engineer** | (none) | manifest review for #125 PR (registry mirror wiring touches CAPI patching) when posted; standby |
-
-**Order of operations within each backend agent**: merge first (the merge work is independent of the Execute gate, since the PR is already through Halt+Verify on a previous session), then SOP for the new issue. Halt before Execute on the new issue and report back.
-
-**Coordination note**: agent C must verify `gh pr view 164 --json state` returns `MERGED` before SOP step 5. If not yet merged, hold at SOP step 4 (Halt) until agent A completes its merge.
+1. **User decides** on the 3 backend Halts — issue #148 (Execute OK?), issue #125 (3 questions), issue #136 (2 picks). Prefer batched OK to keep agents moving.
+2. **Backend agents Execute** their dispatched issues; PRs land normally via Workflow SOP.
+3. **PO opens cross-repo issues** in yage-tofu for `issuing-ca/` and `registry/` modules so the just-merged orchestrator wiring becomes operationally usable.
+4. **Phase H epic #120** closes once #125 lands AND yage-tofu modules ship. Track both arms.
+5. **Manifests migration chain** (#137–#142) unblocks once #136 ships.
 
 ---
 

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -2,88 +2,72 @@
 
 ## Living Memory
 
-yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. Phase H (on-prem platform services via OpenTofu) is next — ADRs 0009/0010/0011 accepted. PR #128 (OpenStack EnsureIdentity) merged to main.
+yage is in active development. The core bootstrap pipeline is functional for Proxmox. The xapiri TUI is being built out as the primary configuration interface. The provider abstraction plan is fully complete: phases A, B, C, D, and E are all done. Legacy cleanup is complete per ADR 0002. ADR 0007: dashboard is the new default xapiri entry point. CSI driver registry (ADR 0001) complete — all 10 drivers merged. Phase H (on-prem platform services via OpenTofu) implementation is underway — ADRs 0009/0010/0011 accepted, most Phase H prereqs merged. The pivot state migration ADR 0011 is fully implemented except #148 (extended HandOff + VerifyParity), which is now unblocked.
 
 ## Freshness Policy
 
 This file must be updated whenever system state evolves (per CODING_STANDARDS.md "Atomic Persistence"). If information here conflicts with what you observe in the code or git history, trust what you observe now — then update this file to match reality.
 
-Last updated: **2026-05-01** — PO session 5: ADR 0011 committed; issues #144–#148 created; yage-manifests epic #133–#142 added; PR #128 merged to main; PR #132 MERGEABLE; PR #143 needs two changes before merge
+Last updated: **2026-05-01** — PO session 6: PRs #157–#165 merged; yage-tofu PRs #2–#3 merged; yage-manifests PR #3 merged; yage-docs PR #9 merged; all licenses added; CodeQL removed from yage + yage-docs; #148, #125, #136 now unblocked.
 
 ## Version Baseline
 
 | Repo | Branch | Recent PRs | Status |
 |---|---|---|---|
-| yage | `main` | #128 (OpenStack EnsureIdentity), #131 (D1 csi.Selector), #130 (ADR 0002 item 7), #129 (vsphere PatchManifest) | Active development |
-| yage-docs | `docs/po-session-3-state-update` | ADRs 0001–0011 written and accepted | PR #8 open, MERGEABLE |
+| yage | `main` | #164 (EnsureRepoSync), #163 (EnsureIssuingCA), #162 (JobRunner k8s backend), #161 (admin token TUI), #160 (EnsureManagementInstall), #159 (profile bugs), #158 (Phase H TUI), #157 (double prompt fix), #156 (timeframe+ctrl+alt fix), #150 (EnsureYageSystemOnCluster), #149 (YAGE_MANIFESTS_REF), #143 (Fetcher PVC resolver), #132 (Phase H config fields) | Active development |
+| yage-docs | `main` | PR #9 (remove codeql.yml), PR #8 (ADRs 0010+0011+CURRENT_STATE) | Up to date |
+| yage-tofu | `main` | PR #2 (kubernetes backend all 8 modules), PR #3 (license) | Up to date |
+| yage-manifests | `init` | PR #3 (license) | Scaffolded, awaiting templates |
 
 ## Recent Changes
 
-### 2026-05-01 — PO session 5: ADR 0011; pivot state migration issues; manifests epic; PR #128 merged
+### 2026-05-01 — PO session 6: Phase H prereqs complete; ADR 0011 fully implemented; licenses; CodeQL removed
 
-**PR merged to main:**
-- **PR #128** merged — `feat(openstack): EnsureIdentity — apply clouds.yaml Secret`. Closes #80. ✅
+**yage PRs merged:**
+- **PR #157** — `fix: skip pickBootstrapConfig before xapiri dashboard`. Closes #151. ✅
+- **PR #158** — `feat(xapiri+plan): surface Phase H registry and issuing CA fields`. Closes #127. ✅
+- **PR #159** — `fix(kindsync+xapiri): config profile system bug fixes`. Closes #153. ✅
+- **PR #160** — `feat(csi): Driver.EnsureManagementInstall — CSI on management cluster (ADR 0011, #147)`. Closes #147. ✅
+- **PR #161** — `feat(xapiri): Proxmox admin token config in TUI; fix AdminToken kind Secret leak`. Closes #152. ✅
+- **PR #162** — `feat(opentofux): switch JobRunner to OpenTofu kubernetes backend; eliminate tofu-state PVCs`. Closes #145 (yage side). ✅
+- **PR #163** — `feat(opentofux): EnsureIssuingCA — generate intermediate CA + wire cert-manager ClusterIssuer`. Closes #126. ✅
+- **PR #164** — `feat(opentofux): implement EnsureRepoSync — yage-repos PVC + yage-repo-sync Job (ADR 0010, #144)`. Closes #144. ✅
+- **PR #165** — `chore: remove codeql.yml`. CodeQL was not gating Merge Gate; removed to clean up check list. ✅
 
-**yage-docs: ADRs 0010 and 0011 committed to `docs/po-session-3-state-update`:**
+**Also merged earlier in session (from session summary):**
+- **PR #156** — fix timeframe `[`/`]` keys on costs tab + remove ctrl+alt+Number tab shortcuts. Closes #154+#155. ✅
 
-- **ADR 0010** — In-cluster repository cache (zero workstation residue): `yage-repos` PVC (500Mi, yage-system), `yage-repo-sync` Job (alpine/git init containers), updated Fetcher structs (MountRoot-based, no CacheDir), registry provisioning rescheduled post-kind. Supersedes local `~/.yage/tofu-cache/` and `~/.yage/manifests-cache/`.
+**yage-tofu PRs merged:**
+- **PR #2** — `feat: switch all modules to OpenTofu kubernetes backend`. Closes #145 (yage-tofu side). All 8 modules now have `backend.tf`. ✅
+- **PR #3** — `chore: add Apache 2.0 license`. ✅
 
-- **ADR 0011** — Pivot: yage state migration to management cluster. Seven decisions:
-  1. Switch `yage-tofu` modules to OpenTofu `kubernetes` backend — state as `tfstate-default-<module>` Secrets in `yage-system` (labeled `app.kubernetes.io/managed-by=yage`); eliminates `tofu-state-<module>` PVCs.
-  2. Extend `HandOffBootstrapSecretsToManagement` with label-based (`app.kubernetes.io/managed-by=yage`) yage-system Secret copy.
-  3. New `EnsureYageSystemOnCluster` — re-creates SA + Role + RoleBinding from in-code spec on any cluster (not copied); prerequisite for tofu kubernetes backend and EnsureRepoSync.
-  4. `csi.Driver.EnsureManagementInstall` — management CSI install on Driver interface (Provider interface stays CSI-free per ADR 0001); Proxmox uses direct Helm (ArgoCD not running on mgmt at this stage).
-  5. `EnsureRepoSync` called on management cluster post-handoff.
-  6. Extended `VerifyParity`: yage-system namespace present + ≥0 labeled Secrets + `yage-repos` PVC Bound.
-  7. Updated pivot sequence with explicit ordering of all new steps.
+**yage-manifests PRs merged:**
+- **PR #3** — `chore: add Apache 2.0 license`. ✅
 
-**New issues created:**
+**yage-docs PRs merged:**
+- **PR #9** — `chore: remove codeql.yml`. ✅
 
-*yage-manifests epic (ADR 0008):*
-- **#133** — epic: yage-manifests — migrate all inline YAML generation to external template repo
-- **#134** — ops: scaffold lpasquali/yage-manifests repository structure
-- **#135** — config: add `YAGE_MANIFESTS_REF` field
-- **#136** — manifests: implement `internal/platform/manifests` Fetcher package
-- **#137** — manifests: migrate `internal/capi/helmvalues/` to yage-manifests templates
-- **#138** — manifests: migrate `internal/capi/wlargocd/` ArgoCD Application renderers
-- **#139** — manifests: migrate `internal/capi/postsync/` renderers
-- **#140** — manifests: migrate `internal/capi/caaph/` string renderers
-- **#141** — csi: migrate `RenderValues` → `Render` + port all 14 drivers to yage-manifests (atomic)
-- **#142** — manifests: retire `internal/capi/helmvalues/`, `wlargocd/`, `postsync/` packages
+**Housekeeping:**
+- Apache 2.0 LICENSE added to all repos that were missing it: `yage-tofu`, `yage-manifests`, `workload-smoketests`. (`yage`, `yage-docs`, `workload-app-of-apps` already had it.)
+- CodeQL removed from `yage` (PR #165) and `yage-docs` (PR #9). Neither check contributed to Merge Gate; they added noise and transient cancellation failures.
+- yage-tofu and yage-manifests rulesets cleaned up: removed `code_quality`, `code_scanning`, `required_status_checks` (yage-tofu has no CI; yage-manifests has no CI). Both keep `pull_request` + `deletion` + `non_fast_forward`.
 
-*Pivot state migration (ADR 0011):*
-- **#144** — orchestrator: create `yage-repos` PVC and run `yage-repo-sync` Job — updated to require cluster-agnostic `EnsureRepoSync` callable on both kind and management cluster
-- **#145** — opentofux: switch yage-tofu modules to OpenTofu kubernetes backend (eliminate `tofu-state-<module>` PVCs)
-- **#146** — kindsync: `EnsureYageSystemOnCluster` — SA + RBAC bootstrap from spec on any cluster
-- **#147** — csi: add `Driver.EnsureManagementInstall` + Proxmox implementation + `PROXMOX_CSI_MGMT_STORAGE_CLASS` field
-- **#148** — kindsync+pivot: extend HandOff with label-based yage-system copy + extend VerifyParity
-
-**PR status:**
-- **PR #132** (`feat/124-phase-h-config-fields`): all CI green, MERGEABLE. **Programmer: merge now.** Closes #124.
-- **PR #143** (`feat/123-opentofux-fetcher-runner`): MERGEABLE by CI but **review comment requires two changes before merge** — (1) `fetcher.go`: replace local clone with PVC path resolver per ADR 0010; (2) `opentofux.go`: delete, do not keep as stub per ADR 0002. Backend must address both, then Programmer merges.
-- **PR #8** (yage-docs `docs/po-session-3-state-update`): MERGEABLE. Contains ADR 0010 + ADR 0011 + CURRENT_STATE. Programmer: merge when ready.
-
-**Issue updates:**
-- **#123**: Acceptance criteria updated — Fetcher is PVC path resolver (no local clone), `opentofux.go` deleted. Review comment left on PR #143 documenting required changes.
-- **#125**: Now also blocked on #144 (EnsureRepoSync) in addition to #123 + #124.
-- **#136**: Fetcher interface updated per ADR 0010 (MountRoot-based, no CacheDir/RepoURL/Ref).
+**Issues closed this session:**
+- #126 (EnsureIssuingCA) — PR #163 ✅
+- #127 (Phase H TUI) — PR #158 ✅
+- #144 (EnsureRepoSync) — PR #164 ✅
+- #145 (kubernetes backend) — PR #162 + yage-tofu PR #2 ✅
+- #147 (EnsureManagementInstall) — PR #160 ✅
+- #151 (double prompt) — PR #157 ✅
+- #152 (admin token TUI) — PR #161 ✅
+- #153 (profile bugs) — PR #159 ✅
+- #154 (timeframe keys) + #155 (ctrl+alt shortcuts) — PR #156 ✅
 
 ---
 
-### 2026-05-01 — PO session 4: PRs #129–#131 reconciled; Phase H issues #123–#127 added to Active Work; PR #128 ready to merge
+### 2026-05-01 — PO session 5 (earlier): ADR 0011; pivot state migration issues; manifests epic
 
-**PRs merged to main (2026-04-30 late, not reflected in previous CURRENT_STATE update):**
-
-- **PR #129** merged — `feat(vsphere): PatchManifest — honor VSphereMachineTemplate sizing fields`. Closes #79. Backend complete.
-- **PR #130** merged — `refactor(orchestrator): remove redundant InfraProvider=="proxmox" guards (ADR 0002 item 7)`. Closes #71. ADR 0002 item 7 now done.
-- **PR #131** merged — `feat(orchestrator): wire csi.Selector; delete internal/capi/csi`. Closes #118. D1 complete; `internal/capi/csi/` deleted from codebase.
-
-**Phase H implementation issues created (all p2, children of epic #120):**
-- **#123** — opentofux: introduce Fetcher+Runner abstraction (Backend, prerequisite for #125 + #126)
-- **#124** — config: add `YAGE_REGISTRY_*` and `YAGE_ISSUING_CA_*` fields (Backend, prerequisite for all)
-- **#125** — orchestrator: provision bootstrap registry VM via OpenTofu (Backend, blocked on #123 + #124 + #144)
-- **#126** — orchestrator: provision online issuing CA + wire cert-manager ClusterIssuer (Backend, blocked on #123 + #124)
-- **#127** — xapiri+plan: surface Phase H registry and issuing CA fields in TUI + `--dry-run` (Frontend/Backend, blocked on #124)
+*(Phase H prereq PRs merged: #132, #143, #149, #150; issues #144–#148, #133–#142, #151–#155 created; PR #128 merged.)*
 
 ---
 
@@ -111,19 +95,9 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 | Issue / PR | Branch | Agent | Description | Status |
 |---|---|---|---|---|
-| PR #132 | `feat/124-phase-h-config-fields` | **Programmer** | Merge PR #132. Closes #124. All CI green. | **Ready** — MERGEABLE |
-| PR #8 (yage-docs) | `docs/po-session-3-state-update` | **Programmer** | Merge PR #8 (ADR 0010 + ADR 0011 + CURRENT_STATE). | **Ready** — MERGEABLE |
-| PR #143 | `feat/123-opentofux-fetcher-runner` | **yage-backend** | Two changes required before merge: (1) `fetcher.go` → PVC path resolver per ADR 0010; (2) delete `opentofux.go` per ADR 0002. Then Programmer merges. | **Needs Backend fix** |
-| #146 | TBD | **yage-backend** | `EnsureYageSystemOnCluster` — SA + Role + RoleBinding from spec on any cluster | **Unblocked** — p1, prerequisite for #144 + #145 |
-| #144 | TBD | **yage-backend** | `EnsureRepoSync` — create `yage-repos` PVC + `yage-repo-sync` Job; cluster-agnostic (kind + mgmt) | **Blocked** on #123 + #135 + #146 |
-| #145 | TBD | **yage-backend** | OpenTofu `kubernetes` backend for yage-tofu modules; eliminates `tofu-state-<module>` PVCs | **Blocked** on #123 + #146 |
-| #147 | TBD | **yage-backend** | `csi.Driver.EnsureManagementInstall` + Proxmox impl + `PROXMOX_CSI_MGMT_STORAGE_CLASS` config field | **Blocked** on #146 |
-| #148 | TBD | **yage-backend** | Extend `HandOffBootstrapSecretsToManagement` (label pass) + extend `VerifyParity` (yage-system + PVC checks) | **Blocked** on #145 + #146 + #144 + #147 |
-| #135 | TBD | **yage-backend** | config: add `YAGE_MANIFESTS_REF` field | **Unblocked** — p2 (can parallel with #123 fix) |
-| #136 | TBD | **yage-backend** | `internal/platform/manifests` Fetcher package (MountRoot-based, no local clone) | **Blocked** on #135 + #144 |
-| #125 | TBD | **yage-backend** | orchestrator: provision bootstrap registry VM via OpenTofu | **Blocked** on #123 + #124 + #144 |
-| #126 | TBD | **yage-backend** | orchestrator: provision online issuing CA + wire cert-manager ClusterIssuer | **Blocked** on #123 + #124 |
-| #127 | TBD | **yage-frontend** / **yage-backend** | xapiri+plan: surface Phase H fields in TUI and `--dry-run` | **Blocked** on #124 (merge PR #132) |
+| #148 | TBD | **yage-backend** | Extend `HandOffBootstrapSecretsToManagement` (label-based yage-system copy) + extend `VerifyParity` (yage-system ns + labeled Secrets + yage-repos PVC) | **Unblocked** — p1, all blockers merged (#144 ✅, #145 ✅, #146 ✅, #147 ✅) |
+| #125 | TBD | **yage-backend** | orchestrator: provision bootstrap registry VM via OpenTofu | **Unblocked** — p2 (was blocked on #123 ✅, #124 ✅, #144 ✅) |
+| #136 | TBD | **yage-backend** | `internal/platform/manifests` Fetcher package (MountRoot-based, no local clone) | **Unblocked** — p2 (was blocked on #135 ✅, #144 ✅) |
 | #134 | TBD | **yage-backend** / **ops** | scaffold `lpasquali/yage-manifests` repo structure | **Unblocked** — p2 |
 | #137 | TBD | **yage-backend** | migrate `internal/capi/helmvalues/` to yage-manifests templates | **Blocked** on #136 |
 | #138 | TBD | **yage-backend** | migrate `internal/capi/wlargocd/` renderers to yage-manifests templates | **Blocked** on #136 |
@@ -138,12 +112,10 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 ## Critical Path (unblocked work agents can start now)
 
-1. **Programmer: merge PR #132** — closes #124; unblocks #127, #125, #126
-2. **Programmer: merge yage-docs PR #8** — publishes ADR 0010 + ADR 0011
-3. **yage-backend: fix PR #143** — address two ADR 0010 review comments, then Programmer merges; closes #123; unblocks #125, #126, #144, #145
-4. **yage-backend: start #146** (`EnsureYageSystemOnCluster`) — unblocked; prerequisite for #144, #145, #147
-5. **yage-backend: start #135** (`YAGE_MANIFESTS_REF` config field) — unblocked; can parallel with #146
-6. **yage-backend: start #134** (scaffold yage-manifests repo) — unblocked; independent
+1. **yage-backend: start #148** (`HandOff` label pass + `VerifyParity` extension) — p1, all prereqs done
+2. **yage-backend: start #125** (registry VM via OpenTofu) — p2, unblocked
+3. **yage-backend: start #136** (`manifests.Fetcher` package) — p2, unblocked; prerequisite for #137–#142
+4. **yage-backend: start #134** (scaffold yage-manifests repo) — p2, independent
 
 ---
 
@@ -152,7 +124,6 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 - xapiri is still a work-in-progress TUI; not all provider paths are fully wired.
 - Cost estimation requires live Proxmox API; returns `ErrUnavailable` when unreachable.
 - vSphere `Inventory()`: `Cores=0` — CPU expressed in MHz only.
-- PR #143 (`feat/123-opentofux-fetcher-runner`) implements the old ADR 0008 §3 Fetcher (local clone to `~/.yage/tofu-cache/`). Must be updated to ADR 0010 PVC path resolver before merge.
 
 ## ADR Index
 

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -25,14 +25,14 @@ Last updated: **2026-05-01** — PO session 7: corrected CURRENT_STATE — PRs #
 
 **Correction:** Session 6 entry below originally listed PRs #161, #163, #164 as merged. GitHub shows all three are still **OPEN with CI green**. Issues #126, #144, #152 remain open until those PRs merge. Session 6 entry corrected; this entry records the dispatch.
 
-**Dispatched (yage-backend, parallel after PR #164 merges):**
-- #148 (p1) — `HandOffBootstrapSecretsToManagement` label-pass + `VerifyParity` extension (closes ADR 0011)
-- #136 (p2) — `internal/platform/manifests` Fetcher package (unblocks #137–#142)
-- #125 (p2) — bootstrap registry VM via OpenTofu (closes Phase H epic #120 alongside PR #163)
+**Per-agent dispatch (each agent merges its assigned PR, then starts the linked issue):**
+- **yage-frontend** — merge PR #161 (closes #152, xapiri admin token TUI). Idle after.
+- **yage-backend (A)** — merge PR #164 (closes #144), then issue #148 (p1) `HandOff` label-pass + `VerifyParity` extension.
+- **yage-backend (B)** — merge PR #163 (closes #126), then issue #125 (p2) bootstrap registry VM via OpenTofu.
+- **yage-backend (C)** — issue #136 (p2) `manifests.Fetcher` package; gate: confirm PR #164 is on `main` before Execute.
+- **yage-architect / yage-platform-engineer** — standby; reactivate for #125 PR manifest review and Phase I ADR scope.
 
-**Awaiting user merge:** PRs #161, #163, #164 (all CI green; rebase onto latest `main` immediately before merge per CodeQL-rescan rule).
-
-**Other agent lanes:** yage-frontend / yage-architect / yage-platform-engineer have no open issues; idle until follow-on work surfaces.
+**Merge protocol** (every agent): rebase onto latest `main` immediately before merging to avoid a second CodeQL scan; use `gh pr merge <N> --squash`.
 
 ---
 
@@ -114,12 +114,12 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 | Issue / PR | Branch | Agent | Description | Status |
 |---|---|---|---|---|
-| PR #161 | `worktree-agent-a2aa9a093ec134e40` | **user / yage-backend** | merge xapiri admin token TUI; closes #152 | **CI green** — awaiting merge |
-| PR #163 | `feat/126-issuing-ca` | **user / yage-backend** | merge EnsureIssuingCA; closes #126; advances epic #120 | **CI green** — awaiting merge |
-| PR #164 | `worktree-agent-af60c9cba9f0fffa6` | **user / yage-backend** | merge EnsureRepoSync; closes #144; unblocks #148/#125/#136 | **CI green** — awaiting merge |
-| #148 | TBD | **yage-backend** | Extend `HandOffBootstrapSecretsToManagement` (label-based yage-system copy) + extend `VerifyParity` (yage-system ns + labeled Secrets + yage-repos PVC) | **Dispatched** — p1; starts after PR #164 merges (#144 ✅ on merge, #145 ✅, #146 ✅, #147 ✅) |
-| #136 | TBD | **yage-backend** | `internal/platform/manifests` Fetcher package (MountRoot-based, no local clone) | **Dispatched** — p2; starts after PR #164 merges; prerequisite for #137–#142 |
-| #125 | TBD | **yage-backend** | orchestrator: provision bootstrap registry VM via OpenTofu | **Dispatched** — p2; starts after PR #164 merges (was blocked on #123 ✅, #124 ✅, #144) |
+| PR #161 | `worktree-agent-a2aa9a093ec134e40` | **yage-frontend** | rebase onto `main`, force-push, then `gh pr merge 161 --squash` — closes #152 (xapiri admin token TUI) | **CI green** — assigned for merge |
+| PR #163 | `feat/126-issuing-ca` | **yage-backend (B)** | rebase onto `main`, force-push, then `gh pr merge 163 --squash` — closes #126 (EnsureIssuingCA); advances epic #120 | **CI green** — assigned for merge |
+| PR #164 | `worktree-agent-af60c9cba9f0fffa6` | **yage-backend (A)** | rebase onto `main`, force-push, then `gh pr merge 164 --squash` — closes #144 (EnsureRepoSync); unblocks #148/#136/#125 | **CI green** — assigned for merge |
+| #148 | new branch | **yage-backend (A)** | after merging PR #164, start: extend `HandOffBootstrapSecretsToManagement` (label-based yage-system copy) + extend `VerifyParity` (yage-system ns + labeled Secrets + yage-repos PVC) | **Dispatched** — p1 |
+| #125 | new branch | **yage-backend (B)** | after merging PR #163 and confirming PR #164 merged, start: provision bootstrap registry VM via OpenTofu and auto-wire `ImageRegistryMirror` | **Dispatched** — p2 |
+| #136 | new branch | **yage-backend (C)** | after PR #164 merge confirmed, start: `internal/platform/manifests` Fetcher package (MountRoot-based, no local clone); ADR 0008 step 2 | **Dispatched** — p2; prerequisite for #137–#142 |
 | #137 | TBD | **yage-backend** | migrate `internal/capi/helmvalues/` to yage-manifests templates | **Blocked** on #136 |
 | #138 | TBD | **yage-backend** | migrate `internal/capi/wlargocd/` renderers to yage-manifests templates | **Blocked** on #136 |
 | #139 | TBD | **yage-backend** | migrate `internal/capi/postsync/` renderers to yage-manifests templates | **Blocked** on #136 |
@@ -131,18 +131,22 @@ Tracked in [yage-docs ADR](https://lpasquali.github.io/yage-docs/architecture/ad
 
 ---
 
-## Critical Path (in order)
+## Per-agent dispatch (session 7)
 
-1. **Merge PRs #161, #163, #164** — all CI green; closes #126/#144/#152 and unblocks the next wave
-2. **yage-backend: start #148** (`HandOff` label pass + `VerifyParity` extension) — p1, after PR #164 merges
-3. **yage-backend: start #136** (`manifests.Fetcher` package) — p2; prerequisite for #137–#142
-4. **yage-backend: start #125** (registry VM via OpenTofu) — p2; closes Phase H epic #120 alongside PR #163
+**Each agent: rebase the assigned PR branch onto latest `main`, force-push, then `gh pr merge --squash`. Wait for CI confirmation.** The rebase-immediately-before-merge step is mandatory — see CODING_STANDARDS / SOP step 8 to avoid the second CodeQL scan.
 
-## Other agent lanes (no open issues)
+| Agent | Merge | Then start |
+|---|---|---|
+| **yage-frontend** | PR #161 → closes #152 | (idle) |
+| **yage-backend (A)** | PR #164 → closes #144 | issue #148 (p1) — `HandOff` + `VerifyParity` |
+| **yage-backend (B)** | PR #163 → closes #126 | issue #125 (p2) — registry VM via OpenTofu |
+| **yage-backend (C)** | (none) | issue #136 (p2) — `manifests.Fetcher` package; **gate**: confirm PR #164 merged on `main` before SOP step 5 (Execute) |
+| **yage-architect** | (none) | review ADR scope for Phase I (post yage-manifests migration); standby — no Execute work this session |
+| **yage-platform-engineer** | (none) | manifest review for #125 PR (registry mirror wiring touches CAPI patching) when posted; standby |
 
-- **yage-frontend** — idle; reopen if Phase H/H+ surfaces TUI gaps after PRs land
-- **yage-architect** — idle; next ADR likely Phase I scope after yage-manifests migration completes
-- **yage-platform-engineer** — idle; reactivate for review when CAPI manifest patches return (e.g. registry mirror wiring in #125)
+**Order of operations within each backend agent**: merge first (the merge work is independent of the Execute gate, since the PR is already through Halt+Verify on a previous session), then SOP for the new issue. Halt before Execute on the new issue and report back.
+
+**Coordination note**: agent C must verify `gh pr view 164 --json state` returns `MERGED` before SOP step 5. If not yet merged, hold at SOP step 4 (Halt) until agent A completes its merge.
 
 ---
 


### PR DESCRIPTION
## Summary

CURRENT_STATE.md update covering PO sessions 6, 7, and 8:

**Session 6** — Phase H prereqs complete; ADR 0011 implemented; licenses; CodeQL removed.
- yage PRs #157–#165 merged (EnsureRepoSync, EnsureIssuingCA, EnsureManagementInstall, JobRunner k8s backend, admin token TUI, profile bug fixes, Phase H TUI, double prompt fix, CodeQL removal).
- yage-tofu PR #2 (kubernetes backend) and PR #3 (license) merged.
- yage-manifests PR #3 (license) merged.
- yage-docs PR #9 (CodeQL removal) merged.
- Issues #126, #127, #144, #145, #147, #151–#155 closed.

**Session 7** — Per-agent dispatch with merge PR assignments; PRs #148/#136/#125 dispatched; cross-repo gap surfaced.

**Session 8** — yage PR #166 merged closes #148, fully implements ADR 0011, clears yage-backend (A) HALT. yage-tofu PR #6 (registry) and PR #7 (issuing-ca) opened for architect review. yage-docs PR #11 (ADR 0012) opened. yage-backend (B) rotated from HELD #125 onto unblocked #136.

**Post-rebase fixups** — flipped the following from "in flight" / "open" to "merged" with squash SHAs:
- yage-docs PR #11 (ADR 0012 template layout) — `1cdf251`
- yage-docs PR #12 (ADR 0009 erratum E1) — `20cb4b9`
- yage-docs PR #13 (Phase H runbook) — `c1930af`

The next PO sweep will record yage PR #170 wrapper structs, yage-tofu PR #6/#7/#8 merges, and the docs PR merges in full — that's a separate pass.

## DoD Level

- [x] **Level 1 — Chore / Housekeeping** (CURRENT_STATE.md only, no ADR or code changes)

## Acceptance Criteria Evidence

- [x] Living Memory updated to reflect ADR 0011 fully implemented (PR #166 `bb60c79`).
- [x] Version Baseline updated with all merged PRs across yage / yage-docs / yage-tofu / yage-manifests.
- [x] Active Work table reflects current blocked/HELD/in-progress state across agents.
- [x] HALT Records updated — (A) cleared by PR #166; (B) rotated onto #136.
- [x] Critical Path lists ordered next moves for architect / programmer / backend agents.
- [x] ADR Index reflects ADR 0009 erratum E1 merged, ADR 0011 fully implemented, ADR 0012 accepted.
- [x] Rebased onto main `20cb4b9b`; conflicting session-4/5 commits dropped (already in main via PR #8).

## Audit Checks

No triggers fired. CURRENT_STATE.md only — no ADR edits, no code changes, no schema changes. Rebase resolved by dropping session 4–5 commits already absorbed by PR #8 squash; only sessions 6–8 cherry-picked onto current `main`.

## Breaking Changes

None. Documentation only.