### PR TITLE
ci: add merge-gate aggregator job for stable status-check context

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -28,3 +28,27 @@ jobs:
     with:
       needs-json: ${{ toJson(needs) }}
       merge-gate-excludes: "docs,security"
+
+  # ─── Merge Gate ─────────────────────────────────────────────────────────────
+  # Top-level aggregator that publishes a stable "Merge Gate" status-check
+  # context matching branch ruleset 15762509. The reusable `compliance`
+  # workflow's own merge-gate job is published as "compliance / Merge Gate"
+  # which does not satisfy the literal "Merge Gate" required context. This
+  # mirrors the local merge-gate convention used in yage and yage-tofu.
+  merge-gate:
+    name: Merge Gate
+    needs: [security, docs, compliance]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate upstream results
+        run: |
+          set -euo pipefail
+          ok() { case "$1" in success|skipped) return 0 ;; *) return 1 ;; esac }
+          echo "security:   ${{ needs.security.result }}"
+          echo "docs:       ${{ needs.docs.result }}"
+          echo "compliance: ${{ needs.compliance.result }}"
+          ok "${{ needs.security.result }}"   || { echo "::error::security check failed"; exit 1; }
+          ok "${{ needs.docs.result }}"       || { echo "::error::docs check failed"; exit 1; }
+          ok "${{ needs.compliance.result }}" || { echo "::error::compliance check failed"; exit 1; }
+          echo "Merge Gate Satisfied"


### PR DESCRIPTION
## Summary

Branch ruleset **15762509** on this repo requires the literal status-check context `"Merge Gate"`. The current `quality-gates.yml` invokes `rune-ci`'s `pr-compliance.yml` as a *reusable* workflow under caller job id `compliance`, so GitHub publishes the resulting check as `"compliance / Merge Gate"` — not `"Merge Gate"`. The required context never matches and PRs never auto-fulfill the gate.

`yage` and `yage-tofu` don't have this problem because they use a top-level local `merge-gate` job that exposes the plain `Merge Gate` context. This PR brings `yage-docs` into line with that convention by adding an equivalent top-level aggregator.

The new `merge-gate` job:
1. `needs: [security, docs, compliance]` — gates on every upstream job. `compliance` itself excludes `docs,security` from its internal verify (`merge-gate-excludes: "docs,security"`), so this aggregator is the *only* place those job results get enforced.
2. Uses `if: always()` so a failed upstream still resolves the required context (otherwise the check stays "expected" forever, re-breaking the gate).
3. Mirrors the `ok() { case "$1" in success|skipped) ... }` shape from `yage/.github/workflows/quality-gates.yml` exactly.
4. Publishes a single status check whose context is exactly `Merge Gate`.

**Self-bootstrapping**: GitHub evaluates required checks against the head SHA's check runs, so this PR's own workflow run will publish the new `Merge Gate` context that satisfies ruleset 15762509 — no `--admin` override needed.

## DoD Level

- [x] **Level 1 — Chore / Housekeeping** (CI workflow plumbing fix only; no ADR or product behaviour changes)

## Acceptance Criteria Evidence

- [x] New top-level `merge-gate` job added to `yage-docs/.github/workflows/quality-gates.yml`.
- [x] Job name is exactly `Merge Gate` (matches ruleset 15762509 required context literally).
- [x] `needs: [security, docs, compliance]` covers every upstream job, compensating for the reusable `compliance` workflow's `merge-gate-excludes: "docs,security"`.
- [x] `if: always()` ensures the required check always resolves, never stays "expected".
- [x] Aggregator script mirrors `yage` and `yage-tofu` (`ok()` helper, `success|skipped` accept-list, explicit per-job `::error::` lines).
- [x] No changes to `rune-ci` (shared workflows untouched per constraint).
- [x] No changes to branch-protection ruleset 15762509 (per constraint).
- [x] No changes to `CURRENT_STATE.md` (per constraint).

## Audit Checks

No triggers fired. CI workflow change only — no ADR, no schema, no provider interface, no orchestrator phase, no public API surface affected. Workflow file is the only modified path. Trigger surface (`pull_request` / `push` to `main`/`develop`) and `permissions:` are unchanged from the existing file.

## Breaking Changes

None. Pure additive change. Existing `security`, `docs`, and `compliance` jobs are untouched. The new `Merge Gate` context becomes a required check on the *next* PR after merge — but this is the intended fix, not a breakage. Cross-repo PRs in `yage` / `yage-tofu` continue to operate identically (this PR brings yage-docs *to* their convention).
